### PR TITLE
Added more stats to PlayerStats and OperatorStats

### DIFF
--- a/Dragon6-API/Alignments.cs
+++ b/Dragon6-API/Alignments.cs
@@ -44,6 +44,7 @@ namespace Dragon6.API
             var PlayerObj = await Task.Run( () => JObject.Parse(json));
             return new PlayerStats
             {
+                // Casual
                 Casual_Kills = int.Parse((string)PlayerObj["results"][GUID]["casualpvp_kills:infinite"] ?? "0"),
                 Casual_Deaths = int.Parse((string)PlayerObj["results"][GUID]["casualpvp_death:infinite"] ?? "0"),
                 Casual_KD = float.Parse((string)PlayerObj["results"][GUID]["casualpvp_kills:infinite"] ?? "1") /
@@ -54,10 +55,11 @@ namespace Dragon6.API
                 Casual_WL = float.Parse((string)PlayerObj["results"][GUID]["casualpvp_matchwon:infinite"] ?? "1") /
                             float.Parse((string)PlayerObj["results"][GUID]["casualpvp_matchlost:infinite"] ?? "1"),
 
-                Barricades = int.Parse((string)PlayerObj["results"][GUID]["generalpvp_barricadedeployed:infinite"] ??
-                                       "0"),
-                Reinforcements =
-                    int.Parse((string)PlayerObj["results"][GUID]["generalpvp_reinforcementdeploy:infinite"] ?? "0"),
+                Casual_MatchesPlayed = int.Parse((string)PlayerObj["results"][GUID]["casualpvp_matchplayed:infinite"] ?? "0"),
+
+                // General
+                Barricades = int.Parse((string)PlayerObj["results"][GUID]["generalpvp_barricadedeployed:infinite"] ?? "0"),
+                Reinforcements = int.Parse((string)PlayerObj["results"][GUID]["generalpvp_reinforcementdeploy:infinite"] ?? "0"),
 
                 Downs = int.Parse((string)PlayerObj["results"][GUID]["generalpvp_dbno:infinite"] ?? "0"),
                 Revives = int.Parse((string)PlayerObj["results"][GUID]["generalpvp_revive:infinite"] ?? "0"),
@@ -68,17 +70,26 @@ namespace Dragon6.API
                 Assists = int.Parse((string)PlayerObj["results"][GUID]["generalpvp_killassists:infinite"] ?? "0"),
                 Suicides = int.Parse((string)PlayerObj["results"][GUID]["generalpvp_suicide:infinite"] ?? "0"),
 
+                // Terrorist Hunt
                 THunt_Kills = int.Parse((string)PlayerObj["results"][GUID]["generalpve_kills:infinite"] ?? "0"),
                 THunt_Deaths = int.Parse((string)PlayerObj["results"][GUID]["generalpve_death:infinite"] ?? "0"),
                 THunt_KD = float.Parse((string)PlayerObj["results"][GUID]["generalpve_kills:infinite"] ?? "1") /
                            float.Parse((string)PlayerObj["results"][GUID]["generalpve_death:infinite"] ?? "1"),
 
+                THunt_Wins = int.Parse((string)PlayerObj["results"][GUID]["generalpve_matchwon:infinite"] ?? "0"),
+                THunt_Losses = int.Parse((string)PlayerObj["results"][GUID]["generalpve_matchlost:infinite"] ?? "0"),
+                THunt_WL = float.Parse((string)PlayerObj["results"][GUID]["generalpve_matchwon:infinite"] ?? "1") /
+                           float.Parse((string)PlayerObj["results"][GUID]["generalpve_matchlost:infinite"] ?? "1"),
+                THunt_MatchesPlayed = int.Parse((string)PlayerObj["results"][GUID]["generalpve_matchwon:infinite"] ?? "0") + int.Parse((string)PlayerObj["results"][GUID]["generalpve_matchlost:infinite"] ?? "0"),
+
+                // Gamemodes
                 HIScore_Secure =
                     int.Parse((string)PlayerObj["results"][GUID]["secureareapvp_bestscore:infinite"] ?? "0"),
                 HIScore_Bomb = int.Parse((string)PlayerObj["results"][GUID]["plantbombpvp_bestscore:infinite"] ?? "0"),
                 HIScore_Hostage =
                     int.Parse((string)PlayerObj["results"][GUID]["rescuehostagepvp_bestscore:infinite"] ?? "0"),
 
+                // Time Played
                 TimePlayed_Casual =
                     TimeSpan.FromSeconds(
                         double.Parse((string)PlayerObj["results"][GUID]["casualpvp_timeplayed:infinite"] ?? "0")),
@@ -88,21 +99,35 @@ namespace Dragon6.API
                 TimePlayed_Ranked =
                     TimeSpan.FromSeconds(
                         double.Parse((string)PlayerObj["results"][GUID]["rankedpvp_timeplayed:infinite"] ?? "0")),
+                TimePlayed_General =
+                    TimeSpan.FromSeconds(
+                        double.Parse((string)PlayerObj["results"][GUID]["generalpvp_timeplayed:infinite"] ?? "0")),
+                TimePlayed_Custom =
+                    TimeSpan.FromSeconds(
+                        double.Parse((string)PlayerObj["results"][GUID]["custompvp_timeplayed:infinite"] ?? "0")),
 
+                // Ranked
                 Ranked_Wins = int.Parse((string)PlayerObj["results"][GUID]["rankedpvp_matchwon:infinite"] ?? "0"),
                 Ranked_Losses = int.Parse((string)PlayerObj["results"][GUID]["rankedpvp_matchlost:infinite"] ?? "0"),
                 Ranked_WL = float.Parse((string)PlayerObj["results"][GUID]["rankedpvp_matchwon:infinite"] ?? "1") /
                             float.Parse((string)PlayerObj["results"][GUID]["rankedpvp_matchlost:infinite"] ?? "1"),
+                Ranked_MatchesPlayed = int.Parse((string)PlayerObj["results"][GUID]["rankedpvp_matchplayed:infinite"] ?? "0"),
 
                 Ranked_Kills = int.Parse((string)PlayerObj["results"][GUID]["rankedpvp_kills:infinite"] ?? "0"),
                 Ranked_Deaths = int.Parse((string)PlayerObj["results"][GUID]["rankedpvp_death:infinite"] ?? "0"),
                 Ranked_KD = float.Parse((string)PlayerObj["results"][GUID]["rankedpvp_kills:infinite"] ?? "1") /
                             float.Parse((string)PlayerObj["results"][GUID]["rankedpvp_death:infinite"] ?? "1"),
 
+                // General
                 Wins = int.Parse((string)PlayerObj["results"][GUID]["generalpvp_matchwon:infinite"] ?? "0"),
                 Losses = int.Parse((string)PlayerObj["results"][GUID]["generalpvp_matchlost:infinite"] ?? "0"),
                 Kills = int.Parse((string)PlayerObj["results"][GUID]["generalpvp_kills:infinite"] ?? "0"),
-                Deaths = int.Parse((string)PlayerObj["results"][GUID]["generalpvp_death:infinite"] ?? "0")
+                Deaths = int.Parse((string)PlayerObj["results"][GUID]["generalpvp_death:infinite"] ?? "0"),
+                WL = float.Parse((string)PlayerObj["results"][GUID]["generalpvp_matchwlratio:infinite"] ?? "0"),
+                MatchesPlayed = int.Parse((string)PlayerObj["results"][GUID]["rankedpvp_matchplayed:infinite"] ?? "0")
+                              + int.Parse((string)PlayerObj["results"][GUID]["casualpvp_matchplayed:infinite"] ?? "0")
+                              + int.Parse((string)PlayerObj["results"][GUID]["generalpve_matchwon:infinite"] ?? "0")
+                              + int.Parse((string)PlayerObj["results"][GUID]["generalpve_matchlost:infinite"] ?? "0")
             };
 
         }

--- a/Dragon6-API/OperatorStats.cs
+++ b/Dragon6-API/OperatorStats.cs
@@ -22,6 +22,8 @@ namespace Dragon6.API
         public decimal WL { get; set; }
 
         public int Headshots { get; set; }
+        public int DBNO { get; set; }
+        public int RoundsPlayed { get; set; }
 
         /// <summary>
         /// Get a collection of all individual operator stats in a List
@@ -79,6 +81,9 @@ namespace Dragon6.API
                 var KillsIdentifier = $"operatorpvp_kills:{index}:infinite";
                 var DeathsIdentifier = $"operatorpvp_death:{index}:infinite";
                 var HeadshotsIdentifier = $"operatorpvp_headshot:{index}:infinite";
+                var DBNOIdentifier = $"operatorpvp_dbno:{index}:infinite";
+                var RoundsPlayedIdentifier = $"operatorpvp_roundplayed:{index}:infinite";
+
                 var stats = new OperatorStats
                 {
                     Name = (string) OperatorObj[index],
@@ -87,16 +92,21 @@ namespace Dragon6.API
                     Wins = int.Parse((string) PlayerObj[WinsIdentifier] ?? "0"),
                     Losses = int.Parse((string) PlayerObj[LossIdentifier] ?? "0"),
                     Headshots = int.Parse((string) PlayerObj[HeadshotsIdentifier] ?? "0"),
+                    DBNO = int.Parse((string)PlayerObj[DBNOIdentifier] ?? "0"),
+                    RoundsPlayed = int.Parse((string)PlayerObj[RoundsPlayedIdentifier] ?? "0"),
                     KD = decimal.Round(decimal.Parse((string) PlayerObj[KillsIdentifier] ?? "1") /
                                        decimal.Parse((string) PlayerObj[DeathsIdentifier] ?? "1"), 2),
                     WL = decimal.Round(decimal.Parse((string) PlayerObj[WinsIdentifier] ?? "1") /
                                        decimal.Parse((string) PlayerObj[LossIdentifier] ?? "1"), 2)
                 };
+
                 PlayerObj.Remove(WinsIdentifier);
                 PlayerObj.Remove(LossIdentifier);
                 PlayerObj.Remove(KillsIdentifier);
                 PlayerObj.Remove(DeathsIdentifier);
                 PlayerObj.Remove(HeadshotsIdentifier);
+                PlayerObj.Remove(DBNOIdentifier);
+                PlayerObj.Remove(RoundsPlayedIdentifier);
                 Collection.Add(stats);
             }
 

--- a/Dragon6-API/PlayerStats.cs
+++ b/Dragon6-API/PlayerStats.cs
@@ -16,14 +16,16 @@ namespace Dragon6.API
         public int Losses { get; set; }
         public int Kills { get; set; }
         public int Deaths { get; set; }
+        public float WL { get; set; }
+        public int MatchesPlayed { get; set; }
 
         public int Casual_Kills { get; set; }
         public int Casual_Deaths { get; set; }
         public float Casual_KD { get; set; }
-
         public int Casual_Wins { get; set; }
         public int Casual_Losses { get; set; }
         public float Casual_WL { get; set; }
+        public int Casual_MatchesPlayed { get; set; }
 
         public int Barricades { get; set; }
         public int Reinforcements { get; set; }
@@ -37,6 +39,10 @@ namespace Dragon6.API
         public int THunt_Kills { get; set; }
         public int THunt_Deaths { get; set; }
         public float THunt_KD { get; set; }
+        public int THunt_Wins { get; set; }
+        public int THunt_Losses { get; set; }
+        public float THunt_WL { get; set; }
+        public int THunt_MatchesPlayed { get; set; }
 
         public int HIScore_Bomb { get; set; }
         public int HIScore_Secure { get; set; }
@@ -45,11 +51,16 @@ namespace Dragon6.API
         public TimeSpan TimePlayed_THunt { get; set; }
         public TimeSpan TimePlayed_Casual { get; set; }
         public TimeSpan TimePlayed_Ranked { get; set; }
+        public TimeSpan TimePlayed_General { get; set; }
+        public TimeSpan TimePlayed_Custom { get; set; }
 
 
         public int Ranked_Wins { get; set; }
         public int Ranked_Losses { get; set; }
         public float Ranked_WL { get; set; }
+        public float Ranked_MatchesPlayed { get; set; }
+
+        public int rankedpvp_matchplayed { get; set; }
 
         public int Ranked_Kills { get; set; }
         public int Ranked_Deaths { get; set; }


### PR DESCRIPTION
A few stats that I went to access through the API but then found were not implemented fully.

Added to PlayerStats
    WL,
    MatchesPlayed,
    Casual_MatchesPlayed,
    Ranked_MatchesPlayed,
    THunt_Wins,
    THunt_Losses,
    THunt_WL,
    THunt_MatchesPlayed,
    TimePlayed_General,
    TimePlayed_Custom

Added to OperatorStats
    DBNO,
    RoundsPlayed