### PR TITLE
Bug fix attempt

### DIFF
--- a/Dragon6-API/Dragon6-API.csproj
+++ b/Dragon6-API/Dragon6-API.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTitle>Dragon6 API</PackageTitle>
-    <PackageVersion>2019.725.0</PackageVersion>
+    <PackageVersion>2019.731.0</PackageVersion>
     <PackageDescription>A Rainbow Six Stats API for .NET</PackageDescription>
     <PackageSummary>A Rainbow Six Stats API</PackageSummary>
     <PackageIconUrl>https://avatars0.githubusercontent.com/t/3256633?s=280</PackageIconUrl>

--- a/Dragon6-API/Dragon6-API.csproj
+++ b/Dragon6-API/Dragon6-API.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTitle>Dragon6 API</PackageTitle>
-    <PackageVersion>2019.731.0</PackageVersion>
+    <PackageVersion>2019.809.0</PackageVersion>
     <PackageDescription>A Rainbow Six Stats API for .NET</PackageDescription>
     <PackageSummary>A Rainbow Six Stats API</PackageSummary>
     <PackageIconUrl>https://avatars0.githubusercontent.com/t/3256633?s=280</PackageIconUrl>

--- a/Dragon6-API/Processing/Alignments.cs
+++ b/Dragon6-API/Processing/Alignments.cs
@@ -37,10 +37,9 @@ namespace Dragon6.API
         /// </summary>
         /// <param name="json"></param>
         /// <returns></returns>
-        public static async Task<PlayerStats> AlignGeneralStats(string json,string GUID)
+        public static PlayerStats AlignGeneralStats(string json,string GUID)
         {
-            var PlayerObj = await Task.Run(() => JObject.Parse(json));
-            PlayerObj = JObject.FromObject(PlayerObj["results"][GUID]);
+            var PlayerObj = (JObject)JObject.Parse(json)["results"][GUID];
 
             return new PlayerStats
             {

--- a/Dragon6-API/Properties/AssemblyInfo.cs
+++ b/Dragon6-API/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2019.731")]
+[assembly: AssemblyVersion("2019.809")]

--- a/Dragon6-API/Stats/PlayerStats.cs
+++ b/Dragon6-API/Stats/PlayerStats.cs
@@ -63,8 +63,6 @@ namespace Dragon6.API
         public float Ranked_WL { get; set; }
         public float Ranked_MatchesPlayed { get; set; }
 
-        public int rankedpvp_matchplayed { get; set; }
-
         public int Ranked_Kills { get; set; }
         public int Ranked_Deaths { get; set; }
         public float Ranked_KD { get; set; }
@@ -141,7 +139,7 @@ namespace Dragon6.API
             if (request.StatusCode == System.Net.HttpStatusCode.Unauthorized)
                 throw new Exceptions.TokenInvalidException("The Token Provided is invalid or has expired");
 
-            return await Alignments.AlignGeneralStats(await request.Content.ReadAsStringAsync(), GUID);
+            return Alignments.AlignGeneralStats(await request.Content.ReadAsStringAsync(), GUID);
         }
     }
 }


### PR DESCRIPTION
this is an attempt to fix the bug (from mobile app):

```System.ArgumentNullException: Value cannot be null.
Parameter name: o
  Module "Newtonsoft.Json.Linq.JToken", in FromObjectInternal
  Module "Newtonsoft.Json.Linq.JObject", in FromObject
  Module "Newtonsoft.Json.Linq.JObject", in FromObject
  Module "Dragon6.API.Alignments", in AlignGeneralStats
  Module "System.Runtime.ExceptionServices.ExceptionDispatchInfo", in Throw
  Module "System.Runtime.CompilerServices.TaskAwaiter", in ThrowForNonSuccess
  Module "System.Runtime.CompilerServices.TaskAwaiter", in HandleNonSuccessAndDebuggerNotification
  Module "System.Runtime.CompilerServices.TaskAwaiter", in ValidateEnd
  Module "System.Runtime.CompilerServices.TaskAwaiter`1[[Dragon6.API.PlayerStats, Dragon6.API, Version=2019.731.0.0, Culture=neutral, PublicKeyToken=null]]", in GetResult
  Module "Dragon6.API.PlayerStats", in GetStats
  Module "System.Runtime.ExceptionServices.ExceptionDispatchInfo", in Throw
  Module "System.Runtime.CompilerServices.TaskAwaiter", in ThrowForNonSuccess
  Module "System.Runtime.CompilerServices.TaskAwaiter", in HandleNonSuccessAndDebuggerNotification
  Module "System.Runtime.CompilerServices.TaskAwaiter", in ValidateEnd
  Module "System.Runtime.CompilerServices.TaskAwaiter`1[[Dragon6.API.PlayerStats, Dragon6.API, Version=2019.731.0.0, Culture=neutral, PublicKeyToken=null]]", in GetResult
  Module "DragonFruit.Six.Mobile.Core.StatsView.Views.StatsView", in OnAppearing```