### PR TITLE
add weapon stats and cleanup code more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ jobs:
      - mon=`date +%m`
      - day=`date +%d`
      - dotnet pack "Dragon6-API/Dragon6-API.csproj" /p:PackageVersion=$year.$mon.$day -o $outdir -c Release 
-     - dotnet nuget push $outdir/Dragon6.API.$year.$mon.$day.nupkg --api-key $nugetkey --source "https://api.nuget.org/v3/index.json"
+     - dotnet nuget push $outdir/*.nupkg --api-key $nugetkey --source "https://api.nuget.org/v3/index.json"

--- a/Dragon6-API/AccountInfo.cs
+++ b/Dragon6-API/AccountInfo.cs
@@ -41,16 +41,12 @@ namespace Dragon6.API
         /// <returns></returns>
         public static async Task<AccountInfo> GetFromName(string name, References.Platforms platform,string token)
         {
-            var client = new HttpClient();
-            var uri = "https://public-ubiservices.ubi.com/v2/profiles?platformType=";
+            var client = Http.Preset.GetClient(token);
+            var uri = $"{Http.Endpoints.UplayIDServer}?platformType=";
 
             if (platform == References.Platforms.PC) uri += "uplay";
             if (platform == References.Platforms.PSN) uri += "psn";
             if (platform == References.Platforms.XB1) uri += "xbl";
-
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            client.DefaultRequestHeaders.Add("Authorization", "Ubi_v1 t=" + token);
-            client.DefaultRequestHeaders.Add("Ubi-Appid", "39baebad-39e5-4552-8c25-2c9b919064e2");
 
             var response = await client.GetAsync(uri + "&nameOnPlatform=" + name);
             if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
@@ -67,14 +63,10 @@ namespace Dragon6.API
         /// <returns></returns>
         public static async Task<AccountInfo> ReverseID_PC(string GUID,string token)
         {
-            var client = new HttpClient();
-            var uri = "https://public-ubiservices.ubi.com/v2/profiles?platformType=uplay";
+            var client = Http.Preset.GetClient(token);
 
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            client.DefaultRequestHeaders.Add("Authorization", "Ubi_v1 t=" + token);
-            client.DefaultRequestHeaders.Add("Ubi-Appid", "39baebad-39e5-4552-8c25-2c9b919064e2");
+            var content = await client.GetAsync($"{Http.Endpoints.UplayIDServer}?platformType=uplay&idOnPlatform={GUID}");
 
-            var content = await client.GetAsync(uri + "&idOnPlatform=" + GUID);
             if (content.StatusCode == System.Net.HttpStatusCode.Unauthorized)
                 throw new Exceptions.TokenInvalidException("The Token Provided is invalid or has expired");
 

--- a/Dragon6-API/Dragon6-API.csproj
+++ b/Dragon6-API/Dragon6-API.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTitle>Dragon6 API</PackageTitle>
-    <PackageVersion>2019.809.0</PackageVersion>
+    <PackageVersion>2019.826.0</PackageVersion>
     <PackageDescription>A Rainbow Six Stats API for .NET</PackageDescription>
     <PackageSummary>A Rainbow Six Stats API</PackageSummary>
     <PackageIconUrl>https://avatars0.githubusercontent.com/t/3256633?s=280</PackageIconUrl>

--- a/Dragon6-API/Http/Endpoints.cs
+++ b/Dragon6-API/Http/Endpoints.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Dragon6.API.Http
+{
+    public class Endpoints
+    {
+        public static readonly Dictionary<References.Platforms, string> Stats = new Dictionary<References.Platforms, string>
+        {
+            { References.Platforms.PSN, "https://public-ubiservices.ubi.com/v1/spaces/05bfb3f7-6c21-4c42-be1f-97a33fb5cf66/sandboxes/OSBOR_PS4_LNCH_A/playerstats2/statistics" },
+            { References.Platforms.XB1, "https://public-ubiservices.ubi.com/v1/spaces/98a601e5-ca91-4440-b1c5-753f601a2c90/sandboxes/OSBOR_XBOXONE_LNCH_A/playerstats2/statistics" },
+            { References.Platforms.PC, "https://public-ubiservices.ubi.com/v1/spaces/5172a557-50b5-4665-b7db-e3f2e8c5041d/sandboxes/OSBOR_PC_LNCH_A/playerstats2/statistics" }
+        };
+
+        public static readonly Dictionary<References.Platforms, string> RankedStats = new Dictionary<References.Platforms, string>
+        {
+            { References.Platforms.PSN, "https://public-ubiservices.ubi.com/v1/spaces/05bfb3f7-6c21-4c42-be1f-97a33fb5cf66/sandboxes/OSBOR_PS4_LNCH_A/r6karma/players" },
+            { References.Platforms.XB1, "https://public-ubiservices.ubi.com/v1/spaces/98a601e5-ca91-4440-b1c5-753f601a2c90/sandboxes/OSBOR_XBOXONE_LNCH_A/r6karma/players" },
+            { References.Platforms.PC, "https://public-ubiservices.ubi.com/v1/spaces/5172a557-50b5-4665-b7db-e3f2e8c5041d/sandboxes/OSBOR_PC_LNCH_A/r6karma/players" }
+        };
+
+        public static readonly Dictionary<References.Platforms, string> ProfileInfo = new Dictionary<References.Platforms, string>
+        {
+            { References.Platforms.PSN, "https://public-ubiservices.ubi.com/v1/spaces/05bfb3f7-6c21-4c42-be1f-97a33fb5cf66/sandboxes/OSBOR_PS4_LNCH_A/r6playerprofile/playerprofile/progressions" },
+            { References.Platforms.XB1, "https://public-ubiservices.ubi.com/v1/spaces/98a601e5-ca91-4440-b1c5-753f601a2c90/sandboxes/OSBOR_XBOXONE_LNCH_A/r6playerprofile/playerprofile/progressions" },
+            { References.Platforms.PC, "https://public-ubiservices.ubi.com/v1/spaces/5172a557-50b5-4665-b7db-e3f2e8c5041d/sandboxes/OSBOR_PC_LNCH_A/r6playerprofile/playerprofile/progressions" }
+        };
+
+        public const string TokenServer = "https://uplayconnect.ubi.com/ubiservices/v2/profiles/sessions";
+        public const string UplayIDServer = "https://public-ubiservices.ubi.com/v2/profiles";
+    }
+}

--- a/Dragon6-API/Http/HttpClientPreset.cs
+++ b/Dragon6-API/Http/HttpClientPreset.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Dragon6.API.Http
+{
+    public class Preset
+    {
+        /// <summary>
+        /// sets up a new HttpClient with the token already embedded
+        /// </summary>
+        /// <param name="Token"></param>
+        /// <returns></returns>
+        public static System.Net.Http.HttpClient GetClient(string Token)
+        {
+            var client = new System.Net.Http.HttpClient();
+            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            client.DefaultRequestHeaders.Add("Authorization", "Ubi_v1 t=" + Token);
+            client.DefaultRequestHeaders.Add("Ubi-Appid", "39baebad-39e5-4552-8c25-2c9b919064e2");
+
+            return client;
+        }
+
+        /// <summary>
+        /// generates the endpoint to access stats for the account's platform
+        /// </summary>
+        /// <param name="Info"></param>
+        /// <param name="Query"></param>
+        /// <returns></returns>
+        public static string FormStatsURL(AccountInfo Info, string Query) => $"{Http.Endpoints.Stats[Info.Platform]}?populations={Info.GUID}&statistics={Query}";
+        public static string FormAccountInfoURL(References.Platforms Platform, string PlayerIDS) => $"{Http.Endpoints.ProfileInfo[Platform]}?profile_ids={PlayerIDS}";
+
+    }
+}

--- a/Dragon6-API/Processing/Alignments.cs
+++ b/Dragon6-API/Processing/Alignments.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
+using Dragon6.API.Stats;
 
 namespace Dragon6.API
 {
@@ -37,11 +38,11 @@ namespace Dragon6.API
         /// </summary>
         /// <param name="json"></param>
         /// <returns></returns>
-        public static PlayerStats AlignGeneralStats(string json,string GUID)
+        public static General AlignGeneralStats(string json,string GUID)
         {
             var PlayerObj = (JObject)JObject.Parse(json)["results"][GUID];
 
-            return new PlayerStats
+            return new General
             {
                 // Casual
                 Casual_Kills = int.Parse((string)PlayerObj[Consts.Casual.Kills] ?? "0"),
@@ -140,14 +141,14 @@ namespace Dragon6.API
         /// </summary>
         /// <param name="json"></param>
         /// <returns></returns>
-        public static async Task<SeasonalStats> AlignSeason(string json,string GUID)
+        public static async Task<Season> AlignSeason(string json,string GUID)
         {
             var response = await Task.Run(() => JObject.Parse(json));
             response = JObject.FromObject(response["players"][GUID]);
 
-            return new SeasonalStats
+            return new Season
             {
-                Season = (int)response[Consts.RankedSeason.Season],
+                SeasonID = (int)response[Consts.RankedSeason.Season],
                 Rank = (int)response[Consts.RankedSeason.Rank],
                 Max_Rank = (int)response[Consts.RankedSeason.MaxRank],
                 Wins = (int)response[Consts.RankedSeason.Wins],

--- a/Dragon6-API/References.cs
+++ b/Dragon6-API/References.cs
@@ -17,7 +17,7 @@ namespace Dragon6.API
 
         public static string[] Regions = {"EMEA", "APAC", "NCSA"};
 
-        public static Dictionary<int, string> RankNames = new Dictionary<int, string>
+        public static readonly Dictionary<int, string> RankNames = new Dictionary<int, string>
         {
             {0, "Unranked"},
             {1, "Copper 4"},
@@ -43,5 +43,15 @@ namespace Dragon6.API
             {21, "Champion"}
         };
 
+        public static readonly Dictionary<int, string> WeaponClasses = new Dictionary<int, string>
+        {
+            {1, "Assault Rifle"},
+            {2, "SMG"},
+            {3, "LMG"},
+            {4, "Marksman Rifle"},
+            {5, "Handgun"},
+            {6, "Shotgun"},
+            {7, "Machine Pistol"}
+        };
     }
 }

--- a/Dragon6-API/Stats/PlayerStats.cs
+++ b/Dragon6-API/Stats/PlayerStats.cs
@@ -7,9 +7,9 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
-namespace Dragon6.API
+namespace Dragon6.API.Stats
 {
-    public class PlayerStats
+    public class General
     {
         #region Vars
         public int Wins { get; set; }
@@ -76,23 +76,7 @@ namespace Dragon6.API
         /// <returns></returns>
         public static async Task<int> GetLevel(AccountInfo playerInfo,string token)
         {
-            //get GUID from playerInfo
-            var guid = playerInfo.GUID;
-            var client = new HttpClient();
-            var uri =
-                "https://public-ubiservices.ubi.com/v1/spaces/5172a557-50b5-4665-b7db-e3f2e8c5041d/sandboxes/OSBOR_PC_LNCH_A/r6playerprofile/playerprofile/progressions?profile_ids=";
-            if (playerInfo.Platform == References.Platforms.PSN)
-                uri =
-                    "https://public-ubiservices.ubi.com/v1/spaces/05bfb3f7-6c21-4c42-be1f-97a33fb5cf66/sandboxes/OSBOR_PS4_LNCH_A/r6playerprofile/playerprofile/progressions?profile_ids=";
-            if (playerInfo.Platform == References.Platforms.XB1)
-                uri =
-                    "https://public-ubiservices.ubi.com/v1/spaces/98a601e5-ca91-4440-b1c5-753f601a2c90/sandboxes/OSBOR_XBOXONE_LNCH_A/r6playerprofile/playerprofile/progressions?profile_ids=";
-
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            client.DefaultRequestHeaders.Add("Authorization", "Ubi_v1 t=" + token);
-            client.DefaultRequestHeaders.Add("Ubi-Appid", "39baebad-39e5-4552-8c25-2c9b919064e2");
-
-            var request = await client.GetAsync(uri + guid);
+            var request = await Http.Preset.GetClient(token).GetAsync(Http.Preset.FormAccountInfoURL(playerInfo.Platform,playerInfo.GUID));
 
             if (request.StatusCode == System.Net.HttpStatusCode.Unauthorized)
                 throw new Exceptions.TokenInvalidException("The Token Provided is invalid or has expired");
@@ -106,40 +90,14 @@ namespace Dragon6.API
         /// <param name="playerInfo"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        public static async Task<PlayerStats> GetStats(AccountInfo playerInfo,string token)
+        public static async Task<General> GetStats(AccountInfo playerInfo,string token)
         {
-            var GUID = playerInfo.GUID;
-            var client = new HttpClient();
-            string uri;
-
-            switch (playerInfo.Platform)
-            {
-                case References.Platforms.PSN:
-                    uri =
-                        "https://public-ubiservices.ubi.com/v1/spaces/05bfb3f7-6c21-4c42-be1f-97a33fb5cf66/sandboxes/OSBOR_PS4_LNCH_A/playerstats2/statistics?populations=";
-                    break;
-                case References.Platforms.XB1:
-                    uri =
-                        "https://public-ubiservices.ubi.com/v1/spaces/98a601e5-ca91-4440-b1c5-753f601a2c90/sandboxes/OSBOR_XBOXONE_LNCH_A/playerstats2/statistics?populations=";
-                    break;
-                default:
-                    uri =
-                        "https://public-ubiservices.ubi.com/v1/spaces/5172a557-50b5-4665-b7db-e3f2e8c5041d/sandboxes/OSBOR_PC_LNCH_A/playerstats2/statistics?populations=";
-                    break;
-            }
-
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            client.DefaultRequestHeaders.Add("Authorization", "Ubi_v1 t=" + token);
-            client.DefaultRequestHeaders.Add("Ubi-Appid", "39baebad-39e5-4552-8c25-2c9b919064e2");
-
-            var request = await client
-                .GetAsync(uri + GUID +
-                          "&statistics=rankedpvp_death,rankedpvp_kdratio,rankedpvp_kills,rankedpvp_matchlost,rankedpvp_matchplayed,rankedpvp_matchwlratio,rankedpvp_matchwon,rankedpvp_timeplayed,casualpvp_death,casualpvp_kdratio,casualpvp_kills,casualpvp_matchlost,casualpvp_matchplayed,casualpvp_matchwlratio,casualpvp_matchwon,casualpvp_timeplayed,generalpvp_barricadedeployed,generalpvp_dbno,generalpvp_death,generalpvp_headshot,generalpvp_killassists,generalpvp_kills,generalpvp_matchlost,generalpvp_matchwlratio,generalpvp_matchwon,generalpvp_meleekills,generalpvp_reinforcementdeploy,generalpvp_revive,generalpvp_suicide,generalpvp_timeplayed,generalpvp_revive,generalpve_kills,generalpve_death,generalpve_matchwon,generalpve_matchlost,custompvp_timeplayed,plantbombpvp_bestscore,rescuehostagepvp_bestscore,secureareapvp_bestscore,casualpvp_timeplayed,rankedpvp_timeplayed,generalpve_timeplayed,generalpvp_bulletfired,generalpvp_penetrationkills,generalpvp_bullethit");
+            var request = await Http.Preset.GetClient(token).GetAsync(Http.Preset.FormStatsURL(playerInfo, "rankedpvp_death,rankedpvp_kdratio,rankedpvp_kills,rankedpvp_matchlost,rankedpvp_matchplayed,rankedpvp_matchwlratio,rankedpvp_matchwon,rankedpvp_timeplayed,casualpvp_death,casualpvp_kdratio,casualpvp_kills,casualpvp_matchlost,casualpvp_matchplayed,casualpvp_matchwlratio,casualpvp_matchwon,casualpvp_timeplayed,generalpvp_barricadedeployed,generalpvp_dbno,generalpvp_death,generalpvp_headshot,generalpvp_killassists,generalpvp_kills,generalpvp_matchlost,generalpvp_matchwlratio,generalpvp_matchwon,generalpvp_meleekills,generalpvp_reinforcementdeploy,generalpvp_revive,generalpvp_suicide,generalpvp_timeplayed,generalpvp_revive,generalpve_kills,generalpve_death,generalpve_matchwon,generalpve_matchlost,custompvp_timeplayed,plantbombpvp_bestscore,rescuehostagepvp_bestscore,secureareapvp_bestscore,casualpvp_timeplayed,rankedpvp_timeplayed,generalpve_timeplayed,generalpvp_bulletfired,generalpvp_penetrationkills,generalpvp_bullethit"));
 
             if (request.StatusCode == System.Net.HttpStatusCode.Unauthorized)
                 throw new Exceptions.TokenInvalidException("The Token Provided is invalid or has expired");
 
-            return Alignments.AlignGeneralStats(await request.Content.ReadAsStringAsync(), GUID);
+            return Alignments.AlignGeneralStats(await request.Content.ReadAsStringAsync(), playerInfo.GUID);
         }
     }
 }

--- a/Dragon6-API/Stats/SeasonalStats.cs
+++ b/Dragon6-API/Stats/SeasonalStats.cs
@@ -7,11 +7,11 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
-namespace Dragon6.API
+namespace Dragon6.API.Stats
 {
-    public class SeasonalStats
+    public class Season
     {
-        public int Season { get; set; }
+        public int SeasonID { get; set; }
         public int Wins { get; set; }
         public int Losses { get; set; }
         public int Abandons { get; set; }
@@ -27,46 +27,16 @@ namespace Dragon6.API
         /// <param name="Region"></param>
         /// <param name="token"></param>
         /// <returns></returns>
-        public static async Task<SeasonalStats> GetSeason(AccountInfo Player, int SeasonNumber, string Region,string token)
+        public static async Task<Season> GetSeason(AccountInfo Player, string Region,string token, int SeasonNumber = -1)
         {
-            var client = new HttpClient();
-            var uuid = Player.GUID;
-
-            var uri = "";
-            switch (Player.Platform)
-            {
-                case References.Platforms.PC:
-                    uri =
-                        "https://public-ubiservices.ubi.com/v1/spaces/5172a557-50b5-4665-b7db-e3f2e8c5041d/sandboxes/OSBOR_PC_LNCH_A/r6karma/players?board_id=pvp_ranked";
-                    break;
-                case References.Platforms.PSN:
-                    uri =
-                        "https://public-ubiservices.ubi.com/v1/spaces/05bfb3f7-6c21-4c42-be1f-97a33fb5cf66/sandboxes/OSBOR_PS4_LNCH_A/r6karma/players?board_id=pvp_ranked";
-                    break;
-                case References.Platforms.XB1:
-                    uri =
-                        "https://public-ubiservices.ubi.com/v1/spaces/98a601e5-ca91-4440-b1c5-753f601a2c90/sandboxes/OSBOR_XBOXONE_LNCH_A/r6karma/players?board_id=pvp_ranked";
-                    break;
-                default:
-                    uri =
-                        "https://public-ubiservices.ubi.com/v1/spaces/5172a557-50b5-4665-b7db-e3f2e8c5041d/sandboxes/OSBOR_PC_LNCH_A/r6karma/players?board_id=pvp_ranked";
-                    break;
-            }
-
-            var constructor = $"&profile_ids={uuid}&region_id={Region.ToLower()}&season_id={SeasonNumber}";
-
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            client.DefaultRequestHeaders.Add("Authorization", "Ubi_v1 t=" + token);
-            client.DefaultRequestHeaders.Add("Ubi-Appid", "39baebad-39e5-4552-8c25-2c9b919064e2");
-
-            var content = await client.GetAsync(uri + constructor);
+            var content = await Http.Preset.GetClient(token).GetAsync($"{Http.Endpoints.RankedStats[Player.Platform]}?board_id=pvp_ranked&profile_ids={Player.GUID}&region_id={Region.ToLower()}&season_id={SeasonNumber}");
 
             if (content.StatusCode == System.Net.HttpStatusCode.Unauthorized)
                 throw new Exceptions.TokenInvalidException("The Token Provided is invalid or has expired");
 
             var response = await content.Content.ReadAsStringAsync();
 
-            return await Alignments.AlignSeason(response, uuid);
+            return await Alignments.AlignSeason(response, Player.GUID);
         }
 
     }

--- a/Dragon6-API/Stats/WeaponStats.cs
+++ b/Dragon6-API/Stats/WeaponStats.cs
@@ -1,0 +1,57 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dragon6.API.Stats
+{
+    public class Weapon
+    {
+        /// <summary>
+        /// Name of weapon class in english
+        /// </summary>
+        public string WeaponClass { get; set; }
+        public int WeaponClassID { get; set; }
+        public int Kills { get; set; }
+        public int Headshots { get; set; }
+        public long BulletsFired { get; set; }
+        public long BulletsHit { get; set; }
+
+        public static async Task<IEnumerable<Weapon>> GetWeaponStats(AccountInfo UserInfo, string token)
+        {
+            var request = await Http.Preset.GetClient(token).GetAsync(Http.Preset.FormStatsURL(UserInfo, "weapontypepvp_kills,weapontypepvp_headshot,weapontypepvp_bulletfired,weapontypepvp_bullethit"));
+
+            if (request.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                throw new Exceptions.TokenInvalidException("The Token Provided is invalid or has expired");
+
+            var PlayerObj = (JObject)JObject.Parse(await request.Content.ReadAsStringAsync())["results"][UserInfo.GUID];
+
+            //form strings to get data
+            var Collection = new List<Weapon>();
+            foreach (int index in References.WeaponClasses.Keys)
+            {
+                var KillsIdentifier = $"weapontypepvp_kills:{index}:infinite";
+                var HeadshotsIdentifier = $"weapontypepvp_headshot:{index}:infinite";
+                var BulletFiredIdentifier = $"weapontypepvp_bulletfired:{index}:infinite";
+                var BulletHitIdentifier = $"weapontypepvp_bullethit:{index}:infinite";
+
+                var stats = new Weapon
+                {
+                    WeaponClass = (string)References.WeaponClasses[index],
+                    WeaponClassID = index,
+                    Kills = int.Parse((string)PlayerObj[KillsIdentifier] ?? "0"),
+                    Headshots = int.Parse((string)PlayerObj[HeadshotsIdentifier] ?? "0"),
+                    BulletsFired = long.Parse((string)PlayerObj[BulletFiredIdentifier] ?? "0"),
+                    BulletsHit = long.Parse((string)PlayerObj[BulletHitIdentifier] ?? "0"),
+
+                };
+
+                Collection.Add(stats);
+            }
+
+            return Collection;
+
+        }
+    }
+}

--- a/Dragon6-API/Token.cs
+++ b/Dragon6-API/Token.cs
@@ -29,8 +29,7 @@ namespace Dragon6.API
                     $"Basic {credentials}"); //change this to the current user's credentials
                 client.DefaultRequestHeaders.Add("Ubi-Appid", "39baebad-39e5-4552-8c25-2c9b919064e2");
                 var response =
-                    await client.PostAsync("https://uplayconnect.ubi.com/ubiservices/v2/profiles/sessions",
-                        content);
+                    await client.PostAsync(Http.Endpoints.TokenServer, content);
                 if (response.StatusCode == HttpStatusCode.Unauthorized)
                     throw new UnauthorizedAccessException();
 

--- a/Dragon6-Test/Program.cs
+++ b/Dragon6-Test/Program.cs
@@ -5,6 +5,8 @@ using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 
+using Dragon6.API.Stats;
+
 namespace Dragon6.API.Test
 {
     class Program
@@ -14,10 +16,11 @@ namespace Dragon6.API.Test
             string token = await new HttpClient().GetAsync("https://dragon6.dragonfruit.network/api/token").Result.Content.ReadAsStringAsync(); //YOU MUST GET PERMISSION BEFORE USING OUR TOKEN SERVER
             var PlayerInfo = await AccountInfo.ReverseID_PC("14c01250-ef26-4a32-92ba-e04aa557d619", token);
 
-            var GeneralStats = await PlayerStats.GetStats(PlayerInfo, token);
-            var SeasonStats = await SeasonalStats.GetSeason(PlayerInfo, -1, "EMEA", token);
-            var OPStats = await OperatorStats.GetOperatorStats(PlayerInfo, token);
-            var Level = await PlayerStats.GetLevel(PlayerInfo, token);
+            var GeneralStats = await General.GetStats(PlayerInfo, token);
+            var SeasonStats = await Season.GetSeason(PlayerInfo, "EMEA", token);
+            var OPStats = await Operator.GetOperatorStats(PlayerInfo, token);
+            var Weapons = await Weapon.GetWeaponStats(PlayerInfo, token);
+            var Level = await General.GetLevel(PlayerInfo, token);
 
             var Account = new JObject()
             {
@@ -25,7 +28,8 @@ namespace Dragon6.API.Test
                 {"Level",Level},
                 {"GeneralStats",JToken.FromObject(GeneralStats)},
                 {"Ranked",JToken.FromObject(SeasonStats)},
-                {"Operator",JToken.FromObject(OPStats)}
+                {"Operator",JToken.FromObject(OPStats)},
+                {"Weapon", JToken.FromObject(Weapons) }
             };
 
             Console.WriteLine(JsonConvert.SerializeObject(Account, Formatting.Indented));


### PR DESCRIPTION
this basically removes the duplicated HttpClient header setting and moves all the URLS to one file. This will break all stats as they have been moved to `.Stats.General`, `.Stats.Operator`, `.Stats.Weapon`, etc.