### PR TITLE
AccountInfo params addition

### DIFF
--- a/DragonFruit.Six.API/AccountInfo.cs
+++ b/DragonFruit.Six.API/AccountInfo.cs
@@ -38,6 +38,18 @@ namespace DragonFruit.Six.API
         [JsonProperty("guid")]
         public string Guid { get; set; }
 
+        /// <summary>
+        /// Original platform identifier
+        /// </summary>
+        [JsonProperty("platformid")]
+        public string PlatformId { get; set; }
+
+        /// <summary>
+        /// Ubisoft identifier
+        /// </summary>
+        [JsonProperty("userid")]
+        public string UbisoftId { get; set; }
+
         [JsonIgnore]
         public Verification.Verification AccountStatus => Server.GetUser(Guid);
 

--- a/DragonFruit.Six.API/DragonFruit.Six.API.csproj
+++ b/DragonFruit.Six.API/DragonFruit.Six.API.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTitle>Dragon6 API</PackageTitle>
-    <PackageVersion>2020.0123</PackageVersion>
+    <PackageVersion>2020.0124</PackageVersion>
     <PackageDescription>A Rainbow Six Stats API for .NET</PackageDescription>
     <PackageSummary>A Rainbow Six Stats API</PackageSummary>
     <PackageIconUrl>https://avatars0.githubusercontent.com/t/3256633?s=280</PackageIconUrl>

--- a/DragonFruit.Six.API/DragonFruit.Six.API.csproj
+++ b/DragonFruit.Six.API/DragonFruit.Six.API.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageTitle>Dragon6 API</PackageTitle>
-    <PackageVersion>2020.0124</PackageVersion>
+    <PackageVersion>2020.0125</PackageVersion>
     <PackageDescription>A Rainbow Six Stats API for .NET</PackageDescription>
     <PackageSummary>A Rainbow Six Stats API</PackageSummary>
     <PackageIconUrl>https://avatars0.githubusercontent.com/t/3256633?s=280</PackageIconUrl>

--- a/DragonFruit.Six.API/Processing/RawConvert.cs
+++ b/DragonFruit.Six.API/Processing/RawConvert.cs
@@ -23,8 +23,10 @@ namespace DragonFruit.Six.API.Processing
                 yield return new AccountInfo
                 {
                     PlayerName = item.GetString(Accounts.Name),
+                    Platform = PlatformParser.PlatformEnumFor(item.GetString(Accounts.Platform)),
                     Guid = item.GetString(Accounts.ProfileIdentifier),
-                    Platform = PlatformParser.PlatformEnumFor(item.GetString(Accounts.Platform))
+                    PlatformId = item.GetString(Accounts.PlatformIdentifier),
+                    UbisoftId = item.GetString(Accounts.UserIdentifier)
                 };
             }
         }

--- a/DragonFruit.Six.API/Properties/AssemblyInfo.cs
+++ b/DragonFruit.Six.API/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2020.0124")]
+[assembly: AssemblyVersion("2020.0125")]

--- a/DragonFruit.Six.API/Properties/AssemblyInfo.cs
+++ b/DragonFruit.Six.API/Properties/AssemblyInfo.cs
@@ -34,4 +34,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2020.0123")]
+[assembly: AssemblyVersion("2020.0124")]


### PR DESCRIPTION
Add `UbisoftId` and `ProfileId` for apps wanting to save users. The ProfileId is the best thing to use to track a user when the change their username. 