### PR TITLE
Add missing ranked stats

### DIFF
--- a/DragonFruit.Six.API.Demo/Program.cs
+++ b/DragonFruit.Six.API.Demo/Program.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using DragonFruit.Six.API.Enums;
 using DragonFruit.Six.API.Stats;
 using DragonFruit.Six.API.Verification;
 using Newtonsoft.Json;

--- a/DragonFruit.Six.API.Tests/AccountInfoTests.cs
+++ b/DragonFruit.Six.API.Tests/AccountInfoTests.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using DragonFruit.Six.API.Enums;
 using DragonFruit.Six.API.Stats;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/DragonFruit.Six.API.Tests/TestData.cs
+++ b/DragonFruit.Six.API.Tests/TestData.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Net.Http;
+using DragonFruit.Six.API.Enums;
 
 namespace DragonFruit.Six.API.Tests
 {

--- a/DragonFruit.Six.API.sln.DotSettings
+++ b/DragonFruit.Six.API.sln.DotSettings
@@ -337,4 +337,7 @@ Licensed under Apache-2. Please refer to the LICENSE file for more info</s:Strin
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=APAC/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=EMEA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=NSCA/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/DragonFruit.Six.API/AccountInfo.cs
+++ b/DragonFruit.Six.API/AccountInfo.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DragonFruit.Six.API.Enums;
 using DragonFruit.Six.API.Helpers;
 using DragonFruit.Six.API.Processing;
 using DragonFruit.Six.API.Verification;
@@ -49,9 +50,6 @@ namespace DragonFruit.Six.API
         /// </summary>
         [JsonProperty("userid")]
         public string UbisoftId { get; set; }
-
-        [JsonIgnore]
-        public Verification.Verification AccountStatus => Server.GetUser(Guid);
 
         /// <summary>
         /// Get a user's account info

--- a/DragonFruit.Six.API/AccountInfo.cs
+++ b/DragonFruit.Six.API/AccountInfo.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 using DragonFruit.Six.API.Enums;
 using DragonFruit.Six.API.Helpers;
 using DragonFruit.Six.API.Processing;
-using DragonFruit.Six.API.Verification;
 using Newtonsoft.Json;
 
 namespace DragonFruit.Six.API

--- a/DragonFruit.Six.API/Endpoints.cs
+++ b/DragonFruit.Six.API/Endpoints.cs
@@ -2,6 +2,8 @@
 // Licensed under Apache-2. Please refer to the LICENSE file for more info
 
 using System.Collections.Generic;
+using DragonFruit.Six.API.Enums;
+using DragonFruit.Six.API.Stats;
 
 namespace DragonFruit.Six.API
 {
@@ -12,6 +14,17 @@ namespace DragonFruit.Six.API
         public static readonly string StatsBase = BaseEndpoint + "/v1/spaces";
         public static readonly string IdServer = BaseEndpoint + "/v3/profiles";
         public static readonly string TokenServer = IdServer + "/sessions";
+
+        /// <summary>
+        /// Used for <see cref="LoginInfo"/>
+        /// </summary>
+        public static readonly Dictionary<Platforms, string> GameIds =
+            new Dictionary<Platforms, string>
+            {
+                [Platforms.PSN] = "fb4cc4c9-2063-461d-a1e8-84a7d36525fc",
+                [Platforms.XB1] = "4008612d-3baf-49e4-957a-33066726a7bc",
+                [Platforms.PC] = "e3d5ea9e-50bd-43b7-88bf-39794f4e3d40"
+            };
 
         /// <summary>
         /// Used for stats

--- a/DragonFruit.Six.API/Enums/LookupMethod.cs
+++ b/DragonFruit.Six.API/Enums/LookupMethod.cs
@@ -1,0 +1,23 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+namespace DragonFruit.Six.API.Enums
+{
+    public enum LookupMethod
+    {
+        /// <summary>
+        /// Player's name
+        /// </summary>
+        Name,
+
+        /// <summary>
+        /// The User ID, which is global across different ubi games
+        /// </summary>
+        UserId,
+
+        /// <summary>
+        /// Id on the platform, not always the same as the GUID
+        /// </summary>
+        PlatformId
+    }
+}

--- a/DragonFruit.Six.API/Enums/MatchResult.cs
+++ b/DragonFruit.Six.API/Enums/MatchResult.cs
@@ -1,0 +1,13 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+namespace DragonFruit.Six.API.Enums
+{
+    public enum MatchResult
+    {
+        Unknown = 0,
+        Win = 1,
+        Loss = 2,
+        Abandon = 3
+    }
+}

--- a/DragonFruit.Six.API/Enums/OperatorType.cs
+++ b/DragonFruit.Six.API/Enums/OperatorType.cs
@@ -1,0 +1,23 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+namespace DragonFruit.Six.API.Enums
+{
+    public enum OperatorType
+    {
+        /// <summary>
+        /// Attacker or Defender (i.e. Recruit)
+        /// </summary>
+        Independent = 0,
+
+        /// <summary>
+        /// Attacking Operator
+        /// </summary>
+        Attacker = 1,
+
+        /// <summary>
+        /// Defending Operator
+        /// </summary>
+        Defender = 2
+    }
+}

--- a/DragonFruit.Six.API/Enums/Platforms.cs
+++ b/DragonFruit.Six.API/Enums/Platforms.cs
@@ -1,0 +1,12 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+namespace DragonFruit.Six.API.Enums
+{
+    public enum Platforms
+    {
+        PC = 1,
+        PSN = 2,
+        XB1 = 3
+    }
+}

--- a/DragonFruit.Six.API/Enums/Regions.cs
+++ b/DragonFruit.Six.API/Enums/Regions.cs
@@ -1,0 +1,15 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace DragonFruit.Six.API.Enums
+{
+    [SuppressMessage("ReSharper", "InconsistentNaming")]
+    public enum Regions
+    {
+        EMEA,
+        NSCA,
+        APAC
+    }
+}

--- a/DragonFruit.Six.API/Helpers/PlatformParser.cs
+++ b/DragonFruit.Six.API/Helpers/PlatformParser.cs
@@ -2,6 +2,7 @@
 // Licensed under Apache-2. Please refer to the LICENSE file for more info
 
 using System;
+using DragonFruit.Six.API.Enums;
 
 namespace DragonFruit.Six.API.Helpers
 {

--- a/DragonFruit.Six.API/Helpers/d6WebRequest.cs
+++ b/DragonFruit.Six.API/Helpers/d6WebRequest.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using DragonFruit.Common.Storage.Web;
+using DragonFruit.Six.API.Enums;
 using Newtonsoft.Json.Linq;
 
 namespace DragonFruit.Six.API.Helpers

--- a/DragonFruit.Six.API/Processing/RawConvert.cs
+++ b/DragonFruit.Six.API/Processing/RawConvert.cs
@@ -118,15 +118,27 @@ namespace DragonFruit.Six.API.Processing
             return new Season
             {
                 Guid = guid,
-
+                TimeUpdated = json.GetString(SeasonalRanked.TimeUpdated),
                 SeasonId = json.GetByte(SeasonalRanked.Season),
-                Rank = json.GetUInt(SeasonalRanked.Rank),
-                MaxRank = json.GetUInt(SeasonalRanked.MaxRank),
+
+                Kills = json.GetUInt(SeasonalRanked.Kills),
+                Deaths = json.GetUInt(SeasonalRanked.Deaths),
                 Wins = json.GetUInt(SeasonalRanked.Wins),
                 Losses = json.GetUInt(SeasonalRanked.Losses),
                 Abandons = json.GetUInt(SeasonalRanked.Abandons),
+                Rank = json.GetUInt(SeasonalRanked.Rank),
+                MaxRank = json.GetUInt(SeasonalRanked.MaxRank),
                 MMR = json.GetDouble(SeasonalRanked.MMR),
-                MaxMMR = json.GetDouble(SeasonalRanked.MaxMMR)
+                MaxMMR = json.GetDouble(SeasonalRanked.MaxMMR),
+                NextRankMMR = json.GetDouble(SeasonalRanked.NextRankMMR),
+                PreviousRankMMR = json.GetDouble(SeasonalRanked.PreviousRankMMR),
+                SkillMean = json.GetDouble(SeasonalRanked.SkillMean),
+                SkillStdev = json.GetDouble(SeasonalRanked.SkillStdev),
+
+                LastMatchResult = json.GetUInt(SeasonalRanked.LastMatchResult),
+                LastMatchMMRChange = json.GetDouble(SeasonalRanked.LastMatchMMRChange),
+                LastMatchSkillChange = json.GetDouble(SeasonalRanked.LastMatchSkillChange),
+                LastMatchSkillStdevChange = json.GetDouble(SeasonalRanked.LastMatchSkillStdevChange),
             };
         }
 

--- a/DragonFruit.Six.API/Processing/RawConvert.cs
+++ b/DragonFruit.Six.API/Processing/RawConvert.cs
@@ -123,8 +123,10 @@ namespace DragonFruit.Six.API.Processing
 
                 Kills = json.GetUInt(SeasonalRanked.Kills),
                 Deaths = json.GetUInt(SeasonalRanked.Deaths),
+                KD = (json.GetFloat(SeasonalRanked.Kills) / json.GetFloat(SeasonalRanked.Deaths)),
                 Wins = json.GetUInt(SeasonalRanked.Wins),
                 Losses = json.GetUInt(SeasonalRanked.Losses),
+                WL = (json.GetFloat(SeasonalRanked.Wins) / json.GetFloat(SeasonalRanked.Losses)),
                 Abandons = json.GetUInt(SeasonalRanked.Abandons),
                 Rank = json.GetUInt(SeasonalRanked.Rank),
                 MaxRank = json.GetUInt(SeasonalRanked.MaxRank),

--- a/DragonFruit.Six.API/Processing/RawConvert.cs
+++ b/DragonFruit.Six.API/Processing/RawConvert.cs
@@ -123,7 +123,7 @@ namespace DragonFruit.Six.API.Processing
 
                 Kills = json.GetUInt(SeasonalRanked.Kills),
                 Deaths = json.GetUInt(SeasonalRanked.Deaths),
-                KD = (json.GetFloat(SeasonalRanked.Kills) / json.GetFloat(SeasonalRanked.Deaths)),
+                KD = (json.GetFloat(SeasonalRanked.Kills, 1) / json.GetFloat(SeasonalRanked.Deaths, 1)),
                 Wins = json.GetUInt(SeasonalRanked.Wins),
                 Losses = json.GetUInt(SeasonalRanked.Losses),
                 WL = (json.GetFloat(SeasonalRanked.Wins) / json.GetFloat(SeasonalRanked.Losses)),

--- a/DragonFruit.Six.API/Processing/RawConvert.cs
+++ b/DragonFruit.Six.API/Processing/RawConvert.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using DragonFruit.Common.Storage.Shared;
+using DragonFruit.Six.API.Enums;
 using DragonFruit.Six.API.Helpers;
 using DragonFruit.Six.API.Stats;
 using Newtonsoft.Json.Linq;
@@ -118,27 +119,31 @@ namespace DragonFruit.Six.API.Processing
             return new Season
             {
                 Guid = guid,
-                TimeUpdated = DateTime.Parse(json.GetString(SeasonalRanked.TimeUpdated, DateTime.Now.ToString())),
+                TimeUpdated = DateTime.Parse(json.GetString(SeasonalRanked.TimeUpdated, DateTime.Now.ToString(References.Culture)), References.Culture),
                 SeasonId = json.GetByte(SeasonalRanked.Season),
 
                 Kills = json.GetUInt(SeasonalRanked.Kills),
                 Deaths = json.GetUInt(SeasonalRanked.Deaths),
-                KD = (json.GetFloat(SeasonalRanked.Kills, 1) / json.GetFloat(SeasonalRanked.Deaths, 1)),
+                KD = json.GetFloat(SeasonalRanked.Kills, 1) / json.GetFloat(SeasonalRanked.Deaths, 1),
+
                 Wins = json.GetUInt(SeasonalRanked.Wins),
                 Losses = json.GetUInt(SeasonalRanked.Losses),
-                WL = (json.GetFloat(SeasonalRanked.Wins, 1) / json.GetFloat(SeasonalRanked.Losses, 1)),
                 Abandons = json.GetUInt(SeasonalRanked.Abandons),
+                WL = json.GetFloat(SeasonalRanked.Wins, 1) / json.GetFloat(SeasonalRanked.Losses, 1),
+
                 Rank = json.GetUInt(SeasonalRanked.Rank),
                 MaxRank = json.GetUInt(SeasonalRanked.MaxRank),
                 TopRankPosition = json.GetUInt(SeasonalRanked.TopRankPosition),
+
                 MMR = json.GetDouble(SeasonalRanked.MMR),
                 MaxMMR = json.GetDouble(SeasonalRanked.MaxMMR),
                 NextRankMMR = json.GetDouble(SeasonalRanked.NextRankMMR),
                 PreviousRankMMR = json.GetDouble(SeasonalRanked.PreviousRankMMR),
+
                 SkillMean = json.GetDouble(SeasonalRanked.SkillMean),
                 SkillUncertainty = json.GetDouble(SeasonalRanked.SkillUncertainty),
 
-                LastMatchResult = json.GetUInt(SeasonalRanked.LastMatchResult),
+                LastMatchResult = (MatchResult)json.GetUInt(SeasonalRanked.LastMatchResult),
                 LastMatchMMRChange = json.GetDouble(SeasonalRanked.LastMatchMMRChange),
                 LastMatchSkillChange = json.GetDouble(SeasonalRanked.LastMatchSkillChange),
                 LastMatchSkillUncertaintyChange = json.GetDouble(SeasonalRanked.LastMatchSkillUncertaintyChange),

--- a/DragonFruit.Six.API/Processing/RawConvert.cs
+++ b/DragonFruit.Six.API/Processing/RawConvert.cs
@@ -126,7 +126,7 @@ namespace DragonFruit.Six.API.Processing
                 KD = (json.GetFloat(SeasonalRanked.Kills, 1) / json.GetFloat(SeasonalRanked.Deaths, 1)),
                 Wins = json.GetUInt(SeasonalRanked.Wins),
                 Losses = json.GetUInt(SeasonalRanked.Losses),
-                WL = (json.GetFloat(SeasonalRanked.Wins) / json.GetFloat(SeasonalRanked.Losses)),
+                WL = (json.GetFloat(SeasonalRanked.Wins, 1) / json.GetFloat(SeasonalRanked.Losses, 1)),
                 Abandons = json.GetUInt(SeasonalRanked.Abandons),
                 Rank = json.GetUInt(SeasonalRanked.Rank),
                 MaxRank = json.GetUInt(SeasonalRanked.MaxRank),

--- a/DragonFruit.Six.API/Processing/RawConvert.cs
+++ b/DragonFruit.Six.API/Processing/RawConvert.cs
@@ -133,12 +133,12 @@ namespace DragonFruit.Six.API.Processing
                 NextRankMMR = json.GetDouble(SeasonalRanked.NextRankMMR),
                 PreviousRankMMR = json.GetDouble(SeasonalRanked.PreviousRankMMR),
                 SkillMean = json.GetDouble(SeasonalRanked.SkillMean),
-                SkillStdev = json.GetDouble(SeasonalRanked.SkillStdev),
+                SkillUncertainty = json.GetDouble(SeasonalRanked.SkillUncertainty),
 
                 LastMatchResult = json.GetUInt(SeasonalRanked.LastMatchResult),
                 LastMatchMMRChange = json.GetDouble(SeasonalRanked.LastMatchMMRChange),
                 LastMatchSkillChange = json.GetDouble(SeasonalRanked.LastMatchSkillChange),
-                LastMatchSkillStdevChange = json.GetDouble(SeasonalRanked.LastMatchSkillStdevChange),
+                LastMatchSkillUncertaintyChange = json.GetDouble(SeasonalRanked.LastMatchSkillUncertaintyChange),
             };
         }
 

--- a/DragonFruit.Six.API/Processing/RawConvert.cs
+++ b/DragonFruit.Six.API/Processing/RawConvert.cs
@@ -118,7 +118,7 @@ namespace DragonFruit.Six.API.Processing
             return new Season
             {
                 Guid = guid,
-                TimeUpdated = json.GetString(SeasonalRanked.TimeUpdated),
+                TimeUpdated = DateTime.Parse(json.GetString(SeasonalRanked.TimeUpdated, DateTime.Now.ToString())),
                 SeasonId = json.GetByte(SeasonalRanked.Season),
 
                 Kills = json.GetUInt(SeasonalRanked.Kills),

--- a/DragonFruit.Six.API/Processing/RawConvert.cs
+++ b/DragonFruit.Six.API/Processing/RawConvert.cs
@@ -128,6 +128,7 @@ namespace DragonFruit.Six.API.Processing
                 Abandons = json.GetUInt(SeasonalRanked.Abandons),
                 Rank = json.GetUInt(SeasonalRanked.Rank),
                 MaxRank = json.GetUInt(SeasonalRanked.MaxRank),
+                TopRankPosition = json.GetUInt(SeasonalRanked.TopRankPosition),
                 MMR = json.GetDouble(SeasonalRanked.MMR),
                 MaxMMR = json.GetDouble(SeasonalRanked.MaxMMR),
                 NextRankMMR = json.GetDouble(SeasonalRanked.NextRankMMR),

--- a/DragonFruit.Six.API/Processing/Strings.cs
+++ b/DragonFruit.Six.API/Processing/Strings.cs
@@ -47,13 +47,26 @@ namespace DragonFruit.Six.API.Processing
     public static class SeasonalRanked
     {
         public static readonly string Season = "season";
-        public static readonly string Rank = "rank";
-        public static readonly string MaxRank = "max_rank";
+        public static readonly string TimeUpdated = "update_time";
+
+        public static readonly string Kills = "kills";
+        public static readonly string Deaths = "deaths";
         public static readonly string Wins = "wins";
         public static readonly string Losses = "losses";
         public static readonly string Abandons = "abandons";
+        public static readonly string Rank = "rank";
+        public static readonly string MaxRank = "max_rank";
         public static readonly string MMR = "mmr";
         public static readonly string MaxMMR = "max_mmr";
+        public static readonly string NextRankMMR = "next_rank_mmr";
+        public static readonly string PreviousRankMMR = "previous_rank_mmr";
+        public static readonly string SkillMean = "skill_mean";
+        public static readonly string SkillStdev = "skill_stdev";
+
+        public static readonly string LastMatchResult = "last_match_result";
+        public static readonly string LastMatchMMRChange = "last_match_mmr_change";
+        public static readonly string LastMatchSkillChange = "last_match_skill_mean_change";
+        public static readonly string LastMatchSkillStdevChange = "last_match_skill_stdev_change";
     }
 
     public static class GeneralPvE

--- a/DragonFruit.Six.API/Processing/Strings.cs
+++ b/DragonFruit.Six.API/Processing/Strings.cs
@@ -61,12 +61,12 @@ namespace DragonFruit.Six.API.Processing
         public static readonly string NextRankMMR = "next_rank_mmr";
         public static readonly string PreviousRankMMR = "previous_rank_mmr";
         public static readonly string SkillMean = "skill_mean";
-        public static readonly string SkillStdev = "skill_stdev";
+        public static readonly string SkillUncertainty = "skill_stdev";
 
         public static readonly string LastMatchResult = "last_match_result";
         public static readonly string LastMatchMMRChange = "last_match_mmr_change";
         public static readonly string LastMatchSkillChange = "last_match_skill_mean_change";
-        public static readonly string LastMatchSkillStdevChange = "last_match_skill_stdev_change";
+        public static readonly string LastMatchSkillUncertaintyChange = "last_match_skill_stdev_change";
     }
 
     public static class GeneralPvE

--- a/DragonFruit.Six.API/Processing/Strings.cs
+++ b/DragonFruit.Six.API/Processing/Strings.cs
@@ -56,6 +56,7 @@ namespace DragonFruit.Six.API.Processing
         public static readonly string Abandons = "abandons";
         public static readonly string Rank = "rank";
         public static readonly string MaxRank = "max_rank";
+        public static readonly string TopRankPosition = "top_rank_position";
         public static readonly string MMR = "mmr";
         public static readonly string MaxMMR = "max_mmr";
         public static readonly string NextRankMMR = "next_rank_mmr";

--- a/DragonFruit.Six.API/References.cs
+++ b/DragonFruit.Six.API/References.cs
@@ -2,75 +2,13 @@
 // Licensed under Apache-2. Please refer to the LICENSE file for more info
 
 using System.Collections.Generic;
-using DragonFruit.Six.API.Stats;
+using System.Globalization;
 
 namespace DragonFruit.Six.API
 {
-    public enum Platforms
-    {
-        PC = 1,
-        PSN = 2,
-        XB1 = 3
-    }
-
-    public enum LookupMethod
-    {
-        /// <summary>
-        /// Player's name
-        /// </summary>
-        Name,
-
-        /// <summary>
-        /// The User ID, which is global across different ubi games
-        /// </summary>
-        UserId,
-
-        /// <summary>
-        /// Id on the platform, not always the same as the GUID
-        /// </summary>
-        PlatformId
-    }
-
-    public enum OperatorType
-    {
-        /// <summary>
-        /// Attacker or Defender (i.e. Recruit)
-        /// </summary>
-        Independent = 0,
-
-        /// <summary>
-        /// Attacking Operator
-        /// </summary>
-        Attacker = 1,
-
-        /// <summary>
-        /// Defending Operator
-        /// </summary>
-        Defender = 2
-    }
-
     public static class References
     {
-        /// <summary>
-        /// Regions for ranked
-        /// </summary>
-        public static readonly string[] Regions =
-        {
-            "EMEA",
-            "APAC",
-            "NCSA"
-        };
-
-        /// <summary>
-        /// Used for <see cref="LoginInfo"/>
-        /// </summary>
-        public static readonly Dictionary<Platforms, string> GameIds =
-            new Dictionary<Platforms, string>
-            {
-                [Platforms.PSN] = "fb4cc4c9-2063-461d-a1e8-84a7d36525fc",
-                [Platforms.XB1] = "4008612d-3baf-49e4-957a-33066726a7bc",
-                [Platforms.PC] = "e3d5ea9e-50bd-43b7-88bf-39794f4e3d40"
-            };
+        public static readonly CultureInfo Culture = new CultureInfo("en-US", false);
 
         /// <summary>
         /// English Versions of Rank ID -> Names (for operations prior to ember rise)
@@ -145,7 +83,7 @@ namespace DragonFruit.Six.API
         };
 
         /// <summary>
-        /// English Names of Weapon Types
+        /// Weapon Types
         /// </summary>
         public static readonly IReadOnlyDictionary<byte, string> WeaponClasses = new Dictionary<byte, string>
         {

--- a/DragonFruit.Six.API/Stats/LoginInfo.cs
+++ b/DragonFruit.Six.API/Stats/LoginInfo.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using DragonFruit.Common.Storage.Shared;
+using DragonFruit.Six.API.Enums;
 using DragonFruit.Six.API.Helpers;
 using DragonFruit.Six.API.Processing;
 using Newtonsoft.Json.Linq;
@@ -39,9 +40,8 @@ namespace DragonFruit.Six.API.Stats
 
         public static async IAsyncEnumerable<LoginInfo> GetLoginInfoAsync(IEnumerable<AccountInfo> accounts, string token)
         {
-            var url = $"{Endpoints.IdServer}/applications?applicationIds={string.Join(',', References.GameIds.Select(x => x.Value))}&profileIds={string.Join(',', accounts.Select(x => x.Guid))}";
-            var parseCulture = new CultureInfo("en-us");
-            var platformLookup = References.GameIds.ToDictionary(x => x.Value, x => x.Key);
+            var url = $"{Endpoints.IdServer}/applications?applicationIds={string.Join(',', Endpoints.GameIds.Select(x => x.Value))}&profileIds={string.Join(',', accounts.Select(x => x.Guid))}";
+            var platformLookup = Endpoints.GameIds.ToDictionary(x => x.Value, x => x.Key);
 
             var data = (JArray)(await Task.Run(() => d6WebRequest.GetWebObject(url, token)))["applications"];
 
@@ -51,8 +51,8 @@ namespace DragonFruit.Six.API.Stats
                 yield return new LoginInfo
                 {
                     Guid = entry.GetString(LoginData.Guid),
-                    FirstLogin = DateTime.Parse(entry.GetString(LoginData.FirstLogin), parseCulture),
-                    LastLogin = DateTime.Parse(entry.GetString(LoginData.LastLogin), parseCulture),
+                    FirstLogin = DateTime.Parse(entry.GetString(LoginData.FirstLogin), References.Culture),
+                    LastLogin = DateTime.Parse(entry.GetString(LoginData.LastLogin), References.Culture),
                     SessionCount = entry.GetUInt(LoginData.Sessions),
                     Platform = platformLookup[entry.GetString(LoginData.PlatformId)]
                 };

--- a/DragonFruit.Six.API/Stats/LoginInfo.cs
+++ b/DragonFruit.Six.API/Stats/LoginInfo.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using DragonFruit.Common.Storage.Shared;

--- a/DragonFruit.Six.API/Stats/OperatorStats.cs
+++ b/DragonFruit.Six.API/Stats/OperatorStats.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using DragonFruit.Common.Storage.File;
 using DragonFruit.Common.Storage.Shared;
 using DragonFruit.Common.Storage.Web;
+using DragonFruit.Six.API.Enums;
 using DragonFruit.Six.API.Helpers;
 using DragonFruit.Six.API.Processing;
 using Newtonsoft.Json.Linq;

--- a/DragonFruit.Six.API/Stats/SeasonalStats.cs
+++ b/DragonFruit.Six.API/Stats/SeasonalStats.cs
@@ -15,8 +15,17 @@ namespace DragonFruit.Six.API.Stats
         [JsonProperty("guid")]
         public string Guid { get; set; }
 
+        [JsonProperty("update_time")]
+        public string TimeUpdated { get; set; }
+
         [JsonProperty("id")]
         public byte SeasonId { get; set; }
+
+        [JsonProperty("kills")]
+        public uint Kills { get; set; }
+
+        [JsonProperty("deaths")]
+        public uint Deaths { get; set; }
 
         [JsonProperty("wins")]
         public uint Wins { get; set; }
@@ -38,6 +47,31 @@ namespace DragonFruit.Six.API.Stats
 
         [JsonProperty("maxmmr")]
         public double MaxMMR { get; set; }
+
+        [JsonProperty("next_rank_mmr")]
+        public double NextRankMMR { get; set; }
+
+        [JsonProperty("previous_rank_mmr")]
+        public double PreviousRankMMR { get; set; }
+
+        [JsonProperty("skill_mean")]
+        public double SkillMean { get; set; }
+
+        [JsonProperty("skill_stdev")]
+        public double SkillStdev { get; set; } // TODO: Wasn't sure what to call this... Needs to be named more appropriately
+
+        [JsonProperty("last_match_result")]
+        public uint LastMatchResult { get; set; }
+
+        [JsonProperty("last_match_mmr_change")]
+        public double LastMatchMMRChange { get; set; }
+
+        [JsonProperty("last_match_skill_mean_change")]
+        public double LastMatchSkillChange { get; set; }
+
+        [JsonProperty("last_match_skill_stdev_change")]
+        public double LastMatchSkillStdevChange { get; set; } // TODO: Wasn't sure what to call this... Needs to be named more appropriately
+
 
         public static async Task<Season> GetSeason(AccountInfo account, string region, string token) => (await GetSeason(new[] { account }, region, token, -1).ConfigureAwait(false)).First();
 

--- a/DragonFruit.Six.API/Stats/SeasonalStats.cs
+++ b/DragonFruit.Six.API/Stats/SeasonalStats.cs
@@ -43,6 +43,9 @@ namespace DragonFruit.Six.API.Stats
         [JsonProperty("rank")]
         public uint Rank { get; set; }
 
+        [JsonProperty("top_rank_position")]
+        public uint TopRankPosition { get; set; }
+
         [JsonProperty("mmr")]
         public double MMR { get; set; }
 
@@ -59,7 +62,7 @@ namespace DragonFruit.Six.API.Stats
         public double SkillMean { get; set; }
 
         [JsonProperty("skill_stdev")]
-        public double SkillUncertainty { get; set; } // TODO: Wasn't sure what to call this... Needs to be named more appropriately
+        public double SkillUncertainty { get; set; }
 
         [JsonProperty("last_match_result")]
         public uint LastMatchResult { get; set; }
@@ -71,7 +74,7 @@ namespace DragonFruit.Six.API.Stats
         public double LastMatchSkillChange { get; set; }
 
         [JsonProperty("last_match_skill_stdev_change")]
-        public double LastMatchSkillUncertaintyChange { get; set; } // TODO: Wasn't sure what to call this... Needs to be named more appropriately
+        public double LastMatchSkillUncertaintyChange { get; set; }
 
 
         public static async Task<Season> GetSeason(AccountInfo account, string region, string token) => (await GetSeason(new[] { account }, region, token, -1).ConfigureAwait(false)).First();

--- a/DragonFruit.Six.API/Stats/SeasonalStats.cs
+++ b/DragonFruit.Six.API/Stats/SeasonalStats.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DragonFruit.Six.API.Enums;
 using DragonFruit.Six.API.Helpers;
 using DragonFruit.Six.API.Processing;
 using Newtonsoft.Json;
@@ -70,9 +71,8 @@ namespace DragonFruit.Six.API.Stats
         [JsonProperty("skill_stdev")]
         public double SkillUncertainty { get; set; }
 
-        // Todo: Use enum for match result. Default: 0, Win: 1, Loss: 2? - Needs checking first
         [JsonProperty("last_match_result")]
-        public uint LastMatchResult { get; set; }
+        public MatchResult LastMatchResult { get; set; }
 
         [JsonProperty("last_match_mmr_change")]
         public double LastMatchMMRChange { get; set; }
@@ -82,7 +82,6 @@ namespace DragonFruit.Six.API.Stats
 
         [JsonProperty("last_match_skill_stdev_change")]
         public double LastMatchSkillUncertaintyChange { get; set; }
-
 
         public static async Task<Season> GetSeason(AccountInfo account, string region, string token) => (await GetSeason(new[] { account }, region, token, -1).ConfigureAwait(false)).First();
 

--- a/DragonFruit.Six.API/Stats/SeasonalStats.cs
+++ b/DragonFruit.Six.API/Stats/SeasonalStats.cs
@@ -1,6 +1,7 @@
 ﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Please refer to the LICENSE file for more info
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/DragonFruit.Six.API/Stats/SeasonalStats.cs
+++ b/DragonFruit.Six.API/Stats/SeasonalStats.cs
@@ -64,6 +64,8 @@ namespace DragonFruit.Six.API.Stats
         [JsonProperty("skill_stdev")]
         public double SkillUncertainty { get; set; }
 
+
+        // Todo: Use enum for match result. Default: 0, Win: 1?, Loss: 2? - Needs checking first
         [JsonProperty("last_match_result")]
         public uint LastMatchResult { get; set; }
 

--- a/DragonFruit.Six.API/Stats/SeasonalStats.cs
+++ b/DragonFruit.Six.API/Stats/SeasonalStats.cs
@@ -58,7 +58,7 @@ namespace DragonFruit.Six.API.Stats
         public double SkillMean { get; set; }
 
         [JsonProperty("skill_stdev")]
-        public double SkillStdev { get; set; } // TODO: Wasn't sure what to call this... Needs to be named more appropriately
+        public double SkillUncertainty { get; set; } // TODO: Wasn't sure what to call this... Needs to be named more appropriately
 
         [JsonProperty("last_match_result")]
         public uint LastMatchResult { get; set; }
@@ -70,7 +70,7 @@ namespace DragonFruit.Six.API.Stats
         public double LastMatchSkillChange { get; set; }
 
         [JsonProperty("last_match_skill_stdev_change")]
-        public double LastMatchSkillStdevChange { get; set; } // TODO: Wasn't sure what to call this... Needs to be named more appropriately
+        public double LastMatchSkillUncertaintyChange { get; set; } // TODO: Wasn't sure what to call this... Needs to be named more appropriately
 
 
         public static async Task<Season> GetSeason(AccountInfo account, string region, string token) => (await GetSeason(new[] { account }, region, token, -1).ConfigureAwait(false)).First();

--- a/DragonFruit.Six.API/Stats/SeasonalStats.cs
+++ b/DragonFruit.Six.API/Stats/SeasonalStats.cs
@@ -28,11 +28,17 @@ namespace DragonFruit.Six.API.Stats
         [JsonProperty("deaths")]
         public uint Deaths { get; set; }
 
+        [JsonProperty("kd")]
+        public float KD { get; set; }
+
         [JsonProperty("wins")]
         public uint Wins { get; set; }
 
         [JsonProperty("losses")]
         public uint Losses { get; set; }
+
+        [JsonProperty("wl")]
+        public float WL { get; set; }
 
         [JsonProperty("abandons")]
         public uint Abandons { get; set; }
@@ -64,8 +70,7 @@ namespace DragonFruit.Six.API.Stats
         [JsonProperty("skill_stdev")]
         public double SkillUncertainty { get; set; }
 
-
-        // Todo: Use enum for match result. Default: 0, Win: 1?, Loss: 2? - Needs checking first
+        // Todo: Use enum for match result. Default: 0, Win: 1, Loss: 2? - Needs checking first
         [JsonProperty("last_match_result")]
         public uint LastMatchResult { get; set; }
 

--- a/DragonFruit.Six.API/Stats/SeasonalStats.cs
+++ b/DragonFruit.Six.API/Stats/SeasonalStats.cs
@@ -16,7 +16,7 @@ namespace DragonFruit.Six.API.Stats
         public string Guid { get; set; }
 
         [JsonProperty("update_time")]
-        public string TimeUpdated { get; set; }
+        public DateTime TimeUpdated { get; set; }
 
         [JsonProperty("id")]
         public byte SeasonId { get; set; }


### PR DESCRIPTION
Added ranked TimeUpdated, Kills, Deaths, NextRankMMR, PreviousRankMMR, SkillMean, SkillStdev, LastMatchResult, LastMatchMMRChange, LastMatchSkillChange, LastMatchSkillStdevChange.

SkillStdev and LastMatchSkillStdevChange possibly need renaming as I am not too sure on what "stdev" stands for.

Also, feel free to leave me with some 'todos' towards the repo.