### PR TITLE
add ubisoft ip address tools

### DIFF
--- a/DragonFruit.Six.API.Demo/Program.cs
+++ b/DragonFruit.Six.API.Demo/Program.cs
@@ -17,7 +17,9 @@ namespace DragonFruit.Six.API.Demo
         private static async Task Main(string[] args)
         {
             var d6Client = new Dragon6DemoClient();
-            using var operatorInformationTask = Task.Run(() => d6Client.GetOperatorInfo());
+
+            var operatorInformationTask = Task.Run(() => d6Client.GetOperatorInfo());
+            var locationInfoTask = Task.Run(() => d6Client.GetUserLocationInfo());
 
             var playerInfo = d6Client.GetUser(Platform.PC, LookupMethod.UserId, "14c01250-ef26-4a32-92ba-e04aa557d619");
 
@@ -40,6 +42,7 @@ namespace DragonFruit.Six.API.Demo
 
             var account = new JObject
             {
+                { "ip_organisation", (await locationInfoTask).Organization },
                 { "account", JToken.FromObject(playerInfo) },
                 { "login", JToken.FromObject(loginInfo) },
                 { "level", JToken.FromObject(level) },

--- a/DragonFruit.Six.API.Tests/Tests/UbisoftToolsTests.cs
+++ b/DragonFruit.Six.API.Tests/Tests/UbisoftToolsTests.cs
@@ -8,7 +8,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace DragonFruit.Six.API.Tests.Tests
 {
     [TestClass]
-    public class ServerStatusTests : TestBase
+    public class UbisoftToolsTests : TestBase
     {
         [TestMethod]
         public void TestServerStatus()
@@ -19,6 +19,12 @@ namespace DragonFruit.Six.API.Tests.Tests
             {
                 Trace.WriteLine($"{platform.Platform} | {platform.Status}");
             }
+        }
+
+        [TestMethod]
+        public void TestLocationInfo()
+        {
+            Client.GetUserLocationInfo();
         }
     }
 }

--- a/DragonFruit.Six.API/Data/Extensions/UserLocationInfoExtensions.cs
+++ b/DragonFruit.Six.API/Data/Extensions/UserLocationInfoExtensions.cs
@@ -1,0 +1,19 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using DragonFruit.Six.API.Data.Requests;
+
+namespace DragonFruit.Six.API.Data.Extensions
+{
+    public static class UserLocationInfoExtensions
+    {
+        /// <summary>
+        /// Get the user's IP address and info from the ubisoft servers
+        /// </summary>
+        public static UserLocationInfo GetUserLocationInfo<T>(this T client) where T : Dragon6Client
+        {
+            var request = new UserLocationInfoRequest();
+            return client.Perform<UserLocationInfo>(request);
+        }
+    }
+}

--- a/DragonFruit.Six.API/Data/Requests/UserLocationInfoRequest.cs
+++ b/DragonFruit.Six.API/Data/Requests/UserLocationInfoRequest.cs
@@ -1,0 +1,12 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using DragonFruit.Common.Data;
+
+namespace DragonFruit.Six.API.Data.Requests
+{
+    public class UserLocationInfoRequest : ApiRequest
+    {
+        public override string Path => "https://public-ubiservices.ubi.com/v2/profiles/me/iplocation";
+    }
+}

--- a/DragonFruit.Six.API/Data/UserLocationInfo.cs
+++ b/DragonFruit.Six.API/Data/UserLocationInfo.cs
@@ -1,0 +1,46 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using Newtonsoft.Json;
+
+namespace DragonFruit.Six.API.Data
+{
+    public class UserLocationInfo
+    {
+        [JsonProperty("ip")]
+        public string IP { get; set; }
+
+        [JsonProperty("countryName")]
+        public string CountryName { get; set; }
+
+        [JsonProperty("countryCode")]
+        public string CountryCode { get; set; }
+
+        [JsonProperty("regionName")]
+        public string RegionName { get; set; }
+
+        [JsonProperty("regionCode")]
+        public string RegionCode { get; set; }
+
+        [JsonProperty("city")]
+        public string City { get; set; }
+
+        [JsonProperty("zipCode")]
+        public string ZipCode { get; set; }
+
+        [JsonProperty("timeZone")]
+        public string TimeZone { get; set; }
+
+        [JsonProperty("latitude")]
+        public string Latitude { get; set; }
+
+        [JsonProperty("longitude")]
+        public string Longitude { get; set; }
+
+        [JsonProperty("isp")]
+        public string ServiceProvider { get; set; }
+
+        [JsonProperty("organization")]
+        public string Organization { get; set; }
+    }
+}


### PR DESCRIPTION
Adds a new `UserLocationInfoRequest` that ubisoft exposes without needing a login. Extension `GetUserLocationInfo()` and tests included