### PR TITLE
Add jsonproperties to weapon and operator stats

### DIFF
--- a/DragonFruit.Six.API/Data/OperatorStats.cs
+++ b/DragonFruit.Six.API/Data/OperatorStats.cs
@@ -4,6 +4,7 @@
 using System;
 using DragonFruit.Six.API.Enums;
 using DragonFruit.Six.API.Utils;
+using Newtonsoft.Json;
 
 namespace DragonFruit.Six.API.Data
 {
@@ -16,88 +17,116 @@ namespace DragonFruit.Six.API.Data
         /// <summary>
         /// User Profile ID
         /// </summary>
+        [JsonProperty("id")]
         public string Guid { get; set; }
 
         /// <summary>
         /// Operator name (from datasheet/dictionary)
         /// </summary>
+        [JsonProperty("name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Operator Identifier (from datasheet/dictionary)
         /// </summary>
+        [JsonProperty("index")]
         public string Index { get; set; }
 
         /// <summary>
         /// Logical order (from datasheet/dictionary)
         /// </summary>
+        [JsonProperty("ord")]
         public ushort Order { get; set; }
 
         /// <summary>
         /// Operator Icon (from datasheet)
         /// </summary>
-        public string ImageURL { get; set; }
+        [JsonProperty("img")]
+        public string ImageUrl { get; set; }
 
         /// <summary>
         /// The name of the organisation the operator is from
         /// </summary>
+        [JsonProperty("org")]
         public string Organisation { get; set; }
 
         /// <summary>
         /// The subtitle, as seen underneath the operator's name in game (from datasheet)
         /// </summary>
+        [JsonProperty("sub")]
         public string Subtitle { get; set; }
 
         /// <summary>
         /// The operator's use, attacker/defender (from datasheet)
         /// </summary>
+        [JsonProperty("type")]
         public OperatorType Type { get; set; }
 
         /// <summary>
         /// The string sent to ubi for their gadget action (from datasheet)
         /// </summary>
+        [JsonProperty("actn")]
         public string OperatorActionId { get; set; }
 
         /// <summary>
         /// String used to collect the stats from ubi
         /// </summary>
-        internal string OperatorActionResultId => $"{OperatorActionId}:infinite";
+        [JsonIgnore]
+        internal string OperatorActionResultId => OperatorActionId.ToStatsKey();
 
         /// <summary>
         /// Description of the operator's ability
         /// </summary>
+        [JsonProperty("phrase")]
         public string Action { get; set; }
 
         /// <summary>
         /// Number of times the operator has performed their ability
         /// </summary>
+        [JsonProperty("action_completed")]
         public uint ActionCount { get; set; }
 
         /// <summary>
         /// Total operator headshots
         /// </summary>
+        [JsonProperty("headshots")]
         public uint Headshots { get; set; }
 
         /// <summary>
         /// Total operator downs (the player has downed)
         /// </summary>
+        [JsonProperty("downs")]
         public uint Downs { get; set; }
 
+        [JsonProperty("kills")]
         public uint Kills { get; set; }
+
+        [JsonProperty("deaths")]
         public uint Deaths { get; set; }
 
+        [JsonProperty("wins")]
         public uint Wins { get; set; }
+
+        [JsonProperty("losses")]
         public uint Losses { get; set; }
 
+        [JsonProperty("rounds")]
         public uint RoundsPlayed { get; set; }
+
+        [JsonProperty("exp")]
         public uint Experience { get; set; }
+
+        [JsonProperty("time")]
         internal uint Duration { get; set; }
 
+        [JsonProperty("kd")]
         public float Kd => _kd ??= RatioUtils.RatioOf(Kills, Deaths);
-        public float Wl => _wl ??= RatioUtils.RatioOf(Wins, Losses);
-        public TimeSpan TimePlayed => _timePlayed ??= TimeSpan.FromSeconds(Duration);
 
-        public int HoursPlayed => (int)TimePlayed.TotalHours;
+        [JsonProperty("wl")]
+        public float Wl => _wl ??= RatioUtils.RatioOf(Wins, Losses);
+
+        [JsonIgnore]
+        public TimeSpan TimePlayed => _timePlayed ??= TimeSpan.FromSeconds(Duration);
 
         internal OperatorStats Clone() => (OperatorStats)MemberwiseClone();
     }

--- a/DragonFruit.Six.API/Data/WeaponStats.cs
+++ b/DragonFruit.Six.API/Data/WeaponStats.cs
@@ -3,6 +3,7 @@
 
 using DragonFruit.Six.API.Enums;
 using DragonFruit.Six.API.Utils;
+using Newtonsoft.Json;
 
 namespace DragonFruit.Six.API.Data
 {
@@ -16,46 +17,64 @@ namespace DragonFruit.Six.API.Data
         /// <summary>
         /// Profile Id
         /// </summary>
+        [JsonProperty("id")]
         public string Guid { get; set; }
 
         /// <summary>
         /// <see cref="WeaponType"/> the stats relate to
         /// </summary>
+        [JsonProperty("class")]
         public WeaponType Class { get; set; }
 
         /// <summary>
         /// Total times this class has been picked by the user
         /// </summary>
+        [JsonProperty("picks")]
         public uint TimesChosen { get; set; }
 
+        [JsonProperty("kills")]
         public uint Kills { get; set; }
+
+        [JsonProperty("deaths")]
         public uint Deaths { get; set; }
+
+        [JsonProperty("headshots")]
         public uint Headshots { get; set; }
 
+        [JsonProperty("downs")]
         public uint Downs { get; set; }
+
+        [JsonProperty("down_assists")]
         public uint DownAssists { get; set; }
 
+        [JsonProperty("shots_fired")]
         public uint ShotsFired { get; set; }
+
+        [JsonProperty("shots_landed")]
         public uint ShotsLanded { get; set; }
 
         /// <summary>
         /// Accuracy ratio consisting of <see cref="ShotsLanded"/> to <see cref="ShotsFired"/>
         /// </summary>
+        [JsonProperty("ar")]
         public float Accuracy => _accuracy ??= RatioUtils.RatioOf(ShotsLanded, ShotsFired);
 
         /// <summary>
         /// Efficiency ratio consisting of <see cref="Kills"/> to <see cref="ShotsFired"/>
         /// </summary>
+        [JsonProperty("er")]
         public float Efficiency => _efficiency ??= RatioUtils.RatioOf(Kills, ShotsFired);
 
         /// <summary>
         /// Headshot ratio consisting of <see cref="Headshots"/> to <see cref="ShotsLanded"/>
         /// </summary>
+        [JsonProperty("hr")]
         public float HeadshotRatio => _headshotRatio ??= RatioUtils.RatioOf(Headshots, ShotsLanded);
 
         /// <summary>
         /// Power ratio consisting of <see cref="Kills"/> to <see cref="ShotsLanded"/>
         /// </summary>
+        [JsonProperty("pr")]
         public float Power => _power ??= RatioUtils.RatioOf(Kills, ShotsLanded);
     }
 }

--- a/DragonFruit.Six.API/Utils/OperatorData.cs
+++ b/DragonFruit.Six.API/Utils/OperatorData.cs
@@ -3,14 +3,10 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using DragonFruit.Common.Data;
-using DragonFruit.Common.Data.Extensions;
 using DragonFruit.Common.Data.Services;
 using DragonFruit.Six.API.Data;
 using DragonFruit.Six.API.Data.Requests;
-using DragonFruit.Six.API.Enums;
-using Newtonsoft.Json.Linq;
 
 namespace DragonFruit.Six.API.Utils
 {
@@ -22,7 +18,10 @@ namespace DragonFruit.Six.API.Utils
         /// </summary>
         /// <param name="location"></param>
         /// <returns></returns>
-        public static IEnumerable<OperatorStats> FromFile(string location) => FromArray(FileServices.ReadFile<JArray>(location));
+        public static IEnumerable<OperatorStats> FromFile(string location)
+        {
+            return FileServices.ReadFile<IEnumerable<OperatorStats>>(location);
+        }
 
         /// <summary>
         /// Gets the <see cref="IEnumerable{T}"/> needed to use the <see cref="GetOperatorStats"/> extensions
@@ -31,25 +30,7 @@ namespace DragonFruit.Six.API.Utils
         public static IEnumerable<OperatorStats> GetOperatorInfo(this ApiClient client)
         {
             var request = new OperatorDataRequest(null);
-            var response = client.Perform<JArray>(request);
-            return FromArray(response);
+            return client.Perform<IEnumerable<OperatorStats>>(request);
         }
-
-        /// <summary>
-        /// Converts a valid <see cref="JArray"/> to a collection of <see cref="OperatorStats"/>, to be used when requesting operator data
-        /// </summary>
-        public static IEnumerable<OperatorStats> FromArray(JArray data) =>
-            data.Cast<JObject>().Select(element => new OperatorStats
-            {
-                ImageURL = element.GetString("img"),
-                Name = element.GetString("name"),
-                Organisation = element.GetString("org"),
-                Index = element.GetString("index"),
-                Subtitle = element.GetString("sub"),
-                Type = (OperatorType)element.GetInt("type"),
-                OperatorActionId = element.GetString("actn"),
-                Action = element.GetString("phrase"),
-                Order = element.GetUShort("ord")
-            });
     }
 }


### PR DESCRIPTION
Now makes all the stats have their own proper naming structure, which now just needs to be checked over and made consistent.

Turns out while telerik is really annoying, it's possible to just type the model and the jsonproperty names out manually...