### PR TITLE
add a set of interfaces for kd and wl based stats

### DIFF
--- a/DragonFruit.Six.API/Data/Containers/ModeStatsContainer.cs
+++ b/DragonFruit.Six.API/Data/Containers/ModeStatsContainer.cs
@@ -2,6 +2,7 @@
 // Licensed under Apache-2. Please refer to the LICENSE file for more info
 
 using System;
+using DragonFruit.Six.API.Data.Interfaces;
 using DragonFruit.Six.API.Utils;
 using Newtonsoft.Json;
 
@@ -45,7 +46,7 @@ namespace DragonFruit.Six.API.Data.Containers
         public uint Captures { get; set; }
     }
 
-    public abstract class ModeStatsContainer
+    public abstract class ModeStatsContainer : IHasWl
     {
         private float? _wl;
         private TimeSpan? _timePlayed;

--- a/DragonFruit.Six.API/Data/Containers/PlaylistStatsContainer.cs
+++ b/DragonFruit.Six.API/Data/Containers/PlaylistStatsContainer.cs
@@ -2,42 +2,21 @@
 // Licensed under Apache-2. Please refer to the LICENSE file for more info
 
 using System;
-using DragonFruit.Six.API.Utils;
 using Newtonsoft.Json;
 
 namespace DragonFruit.Six.API.Data.Containers
 {
-    public class PlaylistStatsContainer
+    public class PlaylistStatsContainer : StatsBase
     {
-        private float? _kd;
-        private float? _wl;
         private TimeSpan? _timePlayed;
-
-        [JsonProperty("kills")]
-        public uint Kills { get; set; }
-
-        [JsonProperty("deaths")]
-        public uint Deaths { get; set; }
-
-        [JsonProperty("wins")]
-        public uint Wins { get; set; }
-
-        [JsonProperty("losses")]
-        public uint Losses { get; set; }
 
         [JsonProperty("matches")]
         public uint MatchesPlayed { get; set; }
 
-        [JsonIgnore]
+        [JsonProperty("time")]
         internal uint Duration { get; set; }
 
-        [JsonProperty("kd")]
-        public float Kd => _kd ??= RatioUtils.RatioOf(Kills, Deaths);
-
-        [JsonProperty("wl")]
-        public float Wl => _wl ??= RatioUtils.RatioOf(Wins, Losses);
-
-        [JsonProperty("time")]
+        [JsonIgnore]
         public TimeSpan TimePlayed => _timePlayed ??= TimeSpan.FromSeconds(Duration);
     }
 }

--- a/DragonFruit.Six.API/Data/Interfaces/IHasKd.cs
+++ b/DragonFruit.Six.API/Data/Interfaces/IHasKd.cs
@@ -1,0 +1,13 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+namespace DragonFruit.Six.API.Data.Interfaces
+{
+    public interface IHasKd
+    {
+        public uint Kills { get; set; }
+        public uint Deaths { get; set; }
+
+        public float Kd { get; }
+    }
+}

--- a/DragonFruit.Six.API/Data/Interfaces/IHasWl.cs
+++ b/DragonFruit.Six.API/Data/Interfaces/IHasWl.cs
@@ -1,0 +1,13 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+namespace DragonFruit.Six.API.Data.Interfaces
+{
+    public interface IHasWl
+    {
+        public uint Wins { get; set; }
+        public uint Losses { get; set; }
+
+        public float Wl { get; }
+    }
+}

--- a/DragonFruit.Six.API/Data/OperatorStats.cs
+++ b/DragonFruit.Six.API/Data/OperatorStats.cs
@@ -8,10 +8,8 @@ using Newtonsoft.Json;
 
 namespace DragonFruit.Six.API.Data
 {
-    public class OperatorStats
+    public class OperatorStats : StatsBase
     {
-        private float? _kd;
-        private float? _wl;
         private TimeSpan? _timePlayed;
 
         /// <summary>
@@ -98,18 +96,6 @@ namespace DragonFruit.Six.API.Data
         [JsonProperty("downs")]
         public uint Downs { get; set; }
 
-        [JsonProperty("kills")]
-        public uint Kills { get; set; }
-
-        [JsonProperty("deaths")]
-        public uint Deaths { get; set; }
-
-        [JsonProperty("wins")]
-        public uint Wins { get; set; }
-
-        [JsonProperty("losses")]
-        public uint Losses { get; set; }
-
         [JsonProperty("rounds")]
         public uint RoundsPlayed { get; set; }
 
@@ -118,12 +104,6 @@ namespace DragonFruit.Six.API.Data
 
         [JsonProperty("time")]
         internal uint Duration { get; set; }
-
-        [JsonProperty("kd")]
-        public float Kd => _kd ??= RatioUtils.RatioOf(Kills, Deaths);
-
-        [JsonProperty("wl")]
-        public float Wl => _wl ??= RatioUtils.RatioOf(Wins, Losses);
 
         [JsonIgnore]
         public TimeSpan TimePlayed => _timePlayed ??= TimeSpan.FromSeconds(Duration);

--- a/DragonFruit.Six.API/Data/SeasonStats.cs
+++ b/DragonFruit.Six.API/Data/SeasonStats.cs
@@ -9,11 +9,8 @@ using Newtonsoft.Json;
 
 namespace DragonFruit.Six.API.Data
 {
-    public class SeasonStats
+    public class SeasonStats : StatsBase
     {
-        private float? _kd;
-        private float? _wl;
-
         private RankInfo _rankInfo;
         private RankInfo _maxRankInfo;
 
@@ -29,26 +26,8 @@ namespace DragonFruit.Six.API.Data
         [JsonProperty("last_match_result")]
         public MatchResult LastMatchResult { get; set; }
 
-        [JsonProperty("kills")]
-        public uint Kills { get; set; }
-
-        [JsonProperty("deaths")]
-        public uint Deaths { get; set; }
-
-        [JsonProperty("wins")]
-        public uint Wins { get; set; }
-
-        [JsonProperty("losses")]
-        public uint Losses { get; set; }
-
         [JsonProperty("abandons")]
         public uint Abandons { get; set; }
-
-        [JsonProperty("wl")]
-        public float Wl => _wl ??= RatioUtils.RatioOf(Wins, Losses + Abandons);
-
-        [JsonProperty("kd")]
-        public float Kd => _kd ??= RatioUtils.RatioOf(Kills, Deaths);
 
         #region Rank
 

--- a/DragonFruit.Six.API/Data/StatsBase.cs
+++ b/DragonFruit.Six.API/Data/StatsBase.cs
@@ -1,0 +1,33 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using DragonFruit.Six.API.Data.Interfaces;
+using DragonFruit.Six.API.Utils;
+using Newtonsoft.Json;
+
+namespace DragonFruit.Six.API.Data
+{
+    public abstract class StatsBase : IHasKd, IHasWl
+    {
+        private float? _kd;
+        private float? _wl;
+
+        [JsonProperty("kills")]
+        public uint Kills { get; set; }
+
+        [JsonProperty("deaths")]
+        public uint Deaths { get; set; }
+
+        [JsonProperty("wins")]
+        public uint Wins { get; set; }
+
+        [JsonProperty("losses")]
+        public uint Losses { get; set; }
+
+        [JsonProperty("kd")]
+        public float Kd => _kd ??= RatioUtils.RatioOf(Kills, Deaths);
+
+        [JsonProperty("wl")]
+        public float Wl => _wl ??= RatioUtils.RatioOf(Wins, Losses);
+    }
+}

--- a/DragonFruit.Six.API/Data/WeaponStats.cs
+++ b/DragonFruit.Six.API/Data/WeaponStats.cs
@@ -1,14 +1,16 @@
 ﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Please refer to the LICENSE file for more info
 
+using DragonFruit.Six.API.Data.Interfaces;
 using DragonFruit.Six.API.Enums;
 using DragonFruit.Six.API.Utils;
 using Newtonsoft.Json;
 
 namespace DragonFruit.Six.API.Data
 {
-    public class WeaponStats
+    public class WeaponStats : IHasKd
     {
+        private float? _kd;
         private float? _power;
         private float? _headshotRatio;
         private float? _efficiency;
@@ -52,6 +54,9 @@ namespace DragonFruit.Six.API.Data
 
         [JsonProperty("shots_landed")]
         public uint ShotsLanded { get; set; }
+
+        [JsonProperty("kd")]
+        public float Kd => _kd ??= RatioUtils.RatioOf(Kills, Deaths);
 
         /// <summary>
         /// Accuracy ratio consisting of <see cref="ShotsLanded"/> to <see cref="ShotsFired"/>


### PR DESCRIPTION
closes #166 

Adds 2 interfaces: `IHasKd` and `IHasWl` which are then consumed by `WeaponStats` and `StatsBase`, which then support jsonproperty inheritance.

Hopefully will stop codacy moaning about duplication -_-

Also fwiw the weapon stats were missing a Kd, so thats been added too :)