### PR TITLE
allow operator actioncount to be nullable

### DIFF
--- a/DragonFruit.Six.API/Data/Deserializers/OperatorStatsDeserializer.cs
+++ b/DragonFruit.Six.API/Data/Deserializers/OperatorStatsDeserializer.cs
@@ -36,7 +36,7 @@ namespace DragonFruit.Six.API.Data.Deserializers
                 op.Downs = json.GetUInt(Operator.Downs.ToIndexedStatsKey(op.Index));
 
                 op.Experience = json.GetUInt(Operator.Experience.ToIndexedStatsKey(op.Index));
-                op.ActionCount = json.GetUInt(op.OperatorActionResultId);
+                op.ActionCount = (uint?)json[op.OperatorActionResultId];
 
                 yield return op;
             }

--- a/DragonFruit.Six.API/Data/OperatorStats.cs
+++ b/DragonFruit.Six.API/Data/OperatorStats.cs
@@ -82,7 +82,7 @@ namespace DragonFruit.Six.API.Data
         /// Number of times the operator has performed their ability
         /// </summary>
         [JsonProperty("action_completed")]
-        public uint ActionCount { get; set; }
+        public uint? ActionCount { get; set; }
 
         /// <summary>
         /// Total operator headshots


### PR DESCRIPTION
This is to prepare for worst case scenario that the operator specific stats (like vigil's drones deceived) cannot be retrieved for newer characters (as there are no ubisoft operator datasheets with the keys used in)

other sites can't even find these, so they keep it simple and just go with kd/wl and other stats they don't need to do any extreme guesswork on.

Not a breaking change _per se_, just that extra null checks will need to be added