### PR TITLE
add the base for modern stats

### DIFF
--- a/DragonFruit.Six.API/Data/ClassicOperatorStats.cs
+++ b/DragonFruit.Six.API/Data/ClassicOperatorStats.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 
 namespace DragonFruit.Six.API.Data
 {
-    public class ClassicOperatorStats : StatsBase
+    public class ClassicOperatorStats : ClassicStatsBase
     {
         private TimeSpan? _timePlayed;
 

--- a/DragonFruit.Six.API/Data/ClassicStatsBase.cs
+++ b/DragonFruit.Six.API/Data/ClassicStatsBase.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace DragonFruit.Six.API.Data
 {
-    public abstract class StatsBase : IHasKd, IHasWl
+    public abstract class ClassicStatsBase : IHasKd, IHasWl
     {
         private float? _kd;
         private float? _wl;

--- a/DragonFruit.Six.API/Data/Containers/PlaylistStats.cs
+++ b/DragonFruit.Six.API/Data/Containers/PlaylistStats.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 
 namespace DragonFruit.Six.API.Data.Containers
 {
-    public class PlaylistStats : StatsBase
+    public class PlaylistStats : ClassicStatsBase
     {
         private TimeSpan? _timePlayed;
 

--- a/DragonFruit.Six.API/Data/Requests/Base/ModernStatsRequest.cs
+++ b/DragonFruit.Six.API/Data/Requests/Base/ModernStatsRequest.cs
@@ -1,0 +1,90 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System;
+using DragonFruit.Common.Data.Parameters;
+using DragonFruit.Six.API.Enums;
+using DragonFruit.Six.API.Utils;
+
+namespace DragonFruit.Six.API.Data.Requests.Base
+{
+    public abstract class ModernStatsRequest : UbiApiRequest
+    {
+        private const string DateTimeFormat = "yyyyMMdd";
+
+        private DateTimeOffset? _startDate;
+        private DateTimeOffset? _endDate;
+
+        public override string Path => $"https://r6s-stats.ubisoft.com/v1/current/{RequestType}/{Account.Identifiers.Profile}";
+
+        /// <summary>
+        /// The type of request (general, operators, weapons, etc.)
+        /// </summary>
+        /// <remarks>
+        /// This is the string included in the uri
+        /// </remarks>
+        protected abstract string RequestType { get; }
+
+        /// <summary>
+        /// The account to get stats for
+        /// </summary>
+        public AccountInfo Account { get; }
+
+        /// <summary>
+        /// The <see cref="PlaylistType"/> to get stats for (as a bitwise flag)
+        /// </summary>
+        public PlaylistType Playlist { get; set; } = PlaylistType.All;
+
+        /// <summary>
+        /// Option to filter stats based on whether they were accumulated during an attack or defense round.
+        /// </summary>
+        public OperatorType OperatorType { get; set; } = OperatorType.Independent;
+
+        /// <summary>
+        /// The start date for the stats
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">The date provided was more than 120 days ago</exception>
+        public DateTimeOffset StartDate
+        {
+            get => _startDate ??= DateTimeOffset.Now.AddDays(-7);
+            set
+            {
+                if (DateTimeOffset.UtcNow.AddDays(-120) > value)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), "Date provided was more than 120 days ago. Stats are only held for upto ~6 months before being removed");
+                }
+
+                _startDate = value;
+            }
+        }
+
+        /// <summary>
+        /// The end date for the stats
+        /// </summary>
+        // todo what happens if this is in the future
+        public DateTimeOffset EndDate
+        {
+            get => _endDate ??= DateTimeOffset.Now;
+            set => _endDate = value;
+        }
+
+        [QueryParameter("platform")]
+        private Platform Platform => Account.Platform;
+
+        [QueryParameter("gameMode")]
+        private string PlaylistNames => Playlist.Expand();
+
+        [QueryParameter("startDate")]
+        private string FormattedStartDate => StartDate.UtcDateTime.ToString(DateTimeFormat);
+
+        [QueryParameter("endDate")]
+        private string FormattedEndDate => EndDate.UtcDateTime.ToString(DateTimeFormat);
+
+        [QueryParameter("teamRole")]
+        private string OperatorTypeNames => OperatorType.HasFlag(OperatorType.Independent)
+            // independent = all
+            ? "all"
+            // here we remove the independent flag then expand
+            : (OperatorType & ~OperatorType.Independent).Expand();
+    }
+}

--- a/DragonFruit.Six.API/Data/Requests/Base/ModernStatsRequest.cs
+++ b/DragonFruit.Six.API/Data/Requests/Base/ModernStatsRequest.cs
@@ -17,6 +17,11 @@ namespace DragonFruit.Six.API.Data.Requests.Base
 
         public override string Path => $"https://r6s-stats.ubisoft.com/v1/current/{RequestType}/{Account.Identifiers.Profile}";
 
+        protected ModernStatsRequest(AccountInfo account)
+        {
+            Account = account;
+        }
+
         /// <summary>
         /// The type of request (general, operators, weapons, etc.)
         /// </summary>
@@ -69,21 +74,21 @@ namespace DragonFruit.Six.API.Data.Requests.Base
         }
 
         [QueryParameter("platform")]
-        private Platform Platform => Account.Platform;
+        protected Platform Platform => Account.Platform;
 
         [QueryParameter("gameMode")]
-        private string PlaylistNames => Playlist.Expand();
+        protected string PlaylistNames => Playlist.Expand();
 
         [QueryParameter("startDate")]
-        private string FormattedStartDate => StartDate.UtcDateTime.ToString(DateTimeFormat);
+        protected string FormattedStartDate => StartDate.UtcDateTime.ToString(DateTimeFormat);
 
         [QueryParameter("endDate")]
-        private string FormattedEndDate => EndDate.UtcDateTime.ToString(DateTimeFormat);
+        protected string FormattedEndDate => EndDate.UtcDateTime.ToString(DateTimeFormat);
 
         [QueryParameter("teamRole")]
-        private string OperatorTypeNames => OperatorType.HasFlag(OperatorType.Independent)
+        protected string OperatorTypeNames => OperatorType.HasFlag(OperatorType.Independent)
             // independent = all
-            ? "all"
+            ? (OperatorType.Attacker | OperatorType.Defender).Expand()
             // here we remove the independent flag then expand
             : (OperatorType & ~OperatorType.Independent).Expand();
     }

--- a/DragonFruit.Six.API/Data/Requests/Base/ModernStatsRequest.cs
+++ b/DragonFruit.Six.API/Data/Requests/Base/ModernStatsRequest.cs
@@ -38,7 +38,7 @@ namespace DragonFruit.Six.API.Data.Requests.Base
         /// <summary>
         /// The <see cref="PlaylistType"/> to get stats for (as a bitwise flag)
         /// </summary>
-        public PlaylistType Playlist { get; set; } = PlaylistType.All;
+        public PlaylistType Playlist { get; set; } = PlaylistType.Ranked | PlaylistType.Casual | PlaylistType.Unranked;
 
         /// <summary>
         /// Option to filter stats based on whether they were accumulated during an attack or defense round.

--- a/DragonFruit.Six.API/Data/Requests/TokenRequest.cs
+++ b/DragonFruit.Six.API/Data/Requests/TokenRequest.cs
@@ -4,6 +4,7 @@
 using System.Net.Http;
 using System.Text;
 using DragonFruit.Common.Data;
+using DragonFruit.Common.Data.Extensions;
 using DragonFruit.Six.API.Data.Requests.Base;
 
 namespace DragonFruit.Six.API.Data.Requests
@@ -24,7 +25,7 @@ namespace DragonFruit.Six.API.Data.Requests
         /// </summary>
         public TokenRequest(string b64Login)
         {
-            Headers.Value.Add("Authorization", $"Basic {b64Login}");
+            this.WithAuthHeader($"Basic {b64Login}");
         }
     }
 }

--- a/DragonFruit.Six.API/Data/SeasonStats.cs
+++ b/DragonFruit.Six.API/Data/SeasonStats.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 
 namespace DragonFruit.Six.API.Data
 {
-    public class SeasonStats : StatsBase
+    public class SeasonStats : ClassicStatsBase
     {
         private RankInfo _rankInfo;
         private RankInfo _maxRankInfo;

--- a/DragonFruit.Six.API/Dragon6Client.cs
+++ b/DragonFruit.Six.API/Dragon6Client.cs
@@ -92,6 +92,9 @@ namespace DragonFruit.Six.API
             {
                 HttpStatusCode.Unauthorized => throw new InvalidTokenException(Token),
                 HttpStatusCode.Forbidden => throw new UbisoftErrorException(),
+
+                HttpStatusCode.NoContent => default,
+
                 _ => base.ValidateAndProcess<T>(response, request)
             };
         }

--- a/DragonFruit.Six.API/Dragon6Client.cs
+++ b/DragonFruit.Six.API/Dragon6Client.cs
@@ -1,6 +1,7 @@
 ﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Please refer to the LICENSE file for more info
 
+using System;
 using System.Globalization;
 using System.Net;
 using System.Net.Http;
@@ -43,7 +44,9 @@ namespace DragonFruit.Six.API
         protected Dragon6Client()
         {
             Serializer = new ApiJsonSerializer(Culture);
+
             AppId = UbisoftService.RainbowSix.AppId();
+            SessionId = Guid.NewGuid().ToString();
 
             if (string.IsNullOrEmpty(UserAgent))
             {
@@ -65,6 +68,15 @@ namespace DragonFruit.Six.API
         }
 
         /// <summary>
+        /// Guid generated per-session for using Ubisoft's modern stats
+        /// </summary>
+        public string SessionId
+        {
+            get => Headers["Ubi-SessionId"];
+            private set => Headers["Ubi-SessionId"] = value;
+        }
+
+        /// <summary>
         /// Method for getting a new <see cref="TokenBase"/>
         /// </summary>
         protected abstract TokenBase GetToken();
@@ -76,7 +88,11 @@ namespace DragonFruit.Six.API
                 if (Token?.Expired != false)
                 {
                     Token = GetToken();
+
                     Authorization = $"Ubi_v1 t={Token.Token}";
+
+                    // modern stats require this header?
+                    Headers["Expiration"] = Token.Expiry.UtcDateTime.ToString("u");
                 }
             }
 

--- a/DragonFruit.Six.API/Dragon6Client.cs
+++ b/DragonFruit.Six.API/Dragon6Client.cs
@@ -89,7 +89,7 @@ namespace DragonFruit.Six.API
                 {
                     Token = GetToken();
 
-                    Authorization = $"Ubi_v1 t={Token.Token}";
+                    Authorization = $"ubi_v1 t={Token.Token}";
 
                     // modern stats require this header?
                     Headers["Expiration"] = Token.Expiry.UtcDateTime.ToString("O");

--- a/DragonFruit.Six.API/Dragon6Client.cs
+++ b/DragonFruit.Six.API/Dragon6Client.cs
@@ -69,7 +69,7 @@ namespace DragonFruit.Six.API
         /// </summary>
         protected abstract TokenBase GetToken();
 
-        public T Perform<T>(UbiApiRequest requestData, CancellationToken cancellationToken, CancellationToken token = default) where T : class
+        public T Perform<T>(UbiApiRequest requestData, CancellationToken token = default) where T : class
         {
             lock (_lock)
             {

--- a/DragonFruit.Six.API/Dragon6Client.cs
+++ b/DragonFruit.Six.API/Dragon6Client.cs
@@ -92,7 +92,7 @@ namespace DragonFruit.Six.API
                     Authorization = $"Ubi_v1 t={Token.Token}";
 
                     // modern stats require this header?
-                    Headers["Expiration"] = Token.Expiry.UtcDateTime.ToString("u");
+                    Headers["Expiration"] = Token.Expiry.UtcDateTime.ToString("O");
                 }
             }
 

--- a/DragonFruit.Six.API/DragonFruit.Six.API.csproj
+++ b/DragonFruit.Six.API/DragonFruit.Six.API.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DragonFruit.Common.Data" Version="2020.1201.21" />
+    <PackageReference Include="DragonFruit.Common.Data" Version="2020.1208.22" />
   </ItemGroup>
 
 </Project>

--- a/DragonFruit.Six.API/Enums/OperatorType.cs
+++ b/DragonFruit.Six.API/Enums/OperatorType.cs
@@ -1,8 +1,11 @@
 ﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Please refer to the LICENSE file for more info
 
+using System;
+
 namespace DragonFruit.Six.API.Enums
 {
+    [Flags]
     public enum OperatorType
     {
         /// <summary>

--- a/DragonFruit.Six.API/Enums/OperatorType.cs
+++ b/DragonFruit.Six.API/Enums/OperatorType.cs
@@ -9,11 +9,6 @@ namespace DragonFruit.Six.API.Enums
     public enum OperatorType
     {
         /// <summary>
-        /// Attacker or Defender (i.e. Recruit)
-        /// </summary>
-        Independent = 0,
-
-        /// <summary>
         /// Attacking Operator
         /// </summary>
         Attacker = 1,
@@ -21,6 +16,11 @@ namespace DragonFruit.Six.API.Enums
         /// <summary>
         /// Defending Operator
         /// </summary>
-        Defender = 2
+        Defender = 2,
+
+        /// <summary>
+        /// Attacker or Defender (i.e. Recruit)
+        /// </summary>
+        Independent = 4
     }
 }

--- a/DragonFruit.Six.API/Enums/PlaylistType.cs
+++ b/DragonFruit.Six.API/Enums/PlaylistType.cs
@@ -10,8 +10,6 @@ namespace DragonFruit.Six.API.Enums
     {
         Ranked,
         Casual,
-        Unranked,
-
-        All = Ranked | Casual | Unranked
+        Unranked
     }
 }

--- a/DragonFruit.Six.API/Enums/PlaylistType.cs
+++ b/DragonFruit.Six.API/Enums/PlaylistType.cs
@@ -1,0 +1,17 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System;
+
+namespace DragonFruit.Six.API.Enums
+{
+    [Flags]
+    public enum PlaylistType
+    {
+        Ranked,
+        Casual,
+        Unranked,
+
+        All = Ranked | Casual | Unranked
+    }
+}

--- a/DragonFruit.Six.API/Enums/PlaylistType.cs
+++ b/DragonFruit.Six.API/Enums/PlaylistType.cs
@@ -10,6 +10,8 @@ namespace DragonFruit.Six.API.Enums
     {
         Ranked,
         Casual,
-        Unranked
+        Unranked,
+
+        All = Ranked | Casual | Unranked
     }
 }

--- a/DragonFruit.Six.API/Utils/EnumConversionUtils.cs
+++ b/DragonFruit.Six.API/Utils/EnumConversionUtils.cs
@@ -1,0 +1,22 @@
+﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System;
+using System.Linq;
+
+namespace DragonFruit.Six.API.Utils
+{
+    internal static class EnumConversionUtils
+    {
+        /// <summary>
+        /// Converts a bitwise flag into a comma-separated string
+        /// </summary>
+        public static string Expand<T>(this T enumValue) where T : Enum
+        {
+            return string.Join(",", Enum.GetValues(typeof(T))
+                                        .Cast<T>()
+                                        .Where(x => enumValue.HasFlag(x))
+                                        .Select(x => x.ToString().ToLower()));
+        }
+    }
+}


### PR DESCRIPTION
Again, works towards #172 by adding a `ModernStatsRequest` which is abstract and needs to be implemented for each of the types:

- `summary`
- `operators`
- `weapons`
- `trend`
- `bestmatchweekly` - which will be ignored for now as it's filed under `narrative` instead of `current`