### PR TITLE
refactor incorrect name

### DIFF
--- a/DragonFruit.Six.API/Data/Deserializers/GeneralStatsDeserializer.cs
+++ b/DragonFruit.Six.API/Data/Deserializers/GeneralStatsDeserializer.cs
@@ -9,9 +9,9 @@ using Newtonsoft.Json.Linq;
 
 namespace DragonFruit.Six.API.Data.Deserializers
 {
-    public static class StatsDeserializer
+    public static class GeneralStatsDeserializer
     {
-        public static GeneralStats DeserializeStatsFor(this JObject jObject, string guid)
+        public static GeneralStats DeserializeGeneralStatsFor(this JObject jObject, string guid)
         {
             // try to get the user but if there is nothing return null
             var json = jObject[Misc.Results]?[guid] as JObject;

--- a/DragonFruit.Six.API/Data/Deserializers/StatsDeserializer.cs
+++ b/DragonFruit.Six.API/Data/Deserializers/StatsDeserializer.cs
@@ -11,7 +11,7 @@ namespace DragonFruit.Six.API.Data.Deserializers
 {
     public static class StatsDeserializer
     {
-        public static Stats DeserializeStatsFor(this JObject jObject, string guid)
+        public static GeneralStats DeserializeStatsFor(this JObject jObject, string guid)
         {
             // try to get the user but if there is nothing return null
             var json = jObject[Misc.Results]?[guid] as JObject;
@@ -19,7 +19,7 @@ namespace DragonFruit.Six.API.Data.Deserializers
             if (json == null)
                 return null;
 
-            var result = new Stats
+            var result = new GeneralStats
             {
                 Guid = guid,
 

--- a/DragonFruit.Six.API/Data/Extensions/StatsExtentions.cs
+++ b/DragonFruit.Six.API/Data/Extensions/StatsExtentions.cs
@@ -13,15 +13,15 @@ namespace DragonFruit.Six.API.Data.Extensions
     public static class StatsExtentions
     {
         /// <summary>
-        /// Get the <see cref="Stats"/> (non-seasonal) for an <see cref="AccountInfo"/>
+        /// Get the <see cref="GeneralStats"/> (non-seasonal) for an <see cref="AccountInfo"/>
         /// </summary>
-        public static Stats GetStats<T>(this T client, AccountInfo account, CancellationToken token = default) where T : Dragon6Client 
+        public static GeneralStats GetStats<T>(this T client, AccountInfo account, CancellationToken token = default) where T : Dragon6Client 
             => GetStats(client, new[] { account }, token).First();
 
         /// <summary>
-        /// Get the <see cref="Stats"/> (non-seasonal) for an array of <see cref="AccountInfo"/>s
+        /// Get the <see cref="GeneralStats"/> (non-seasonal) for an array of <see cref="AccountInfo"/>s
         /// </summary>
-        public static IEnumerable<Stats> GetStats<T>(this T client, IEnumerable<AccountInfo> accounts, CancellationToken token = default) where T : Dragon6Client
+        public static IEnumerable<GeneralStats> GetStats<T>(this T client, IEnumerable<AccountInfo> accounts, CancellationToken token = default) where T : Dragon6Client
         {
             var filteredGroups = accounts.GroupBy(x => x.Platform);
 

--- a/DragonFruit.Six.API/Data/Extensions/StatsExtentions.cs
+++ b/DragonFruit.Six.API/Data/Extensions/StatsExtentions.cs
@@ -32,7 +32,7 @@ namespace DragonFruit.Six.API.Data.Extensions
 
                 foreach (var id in request.AccountIds)
                 {
-                    yield return data.DeserializeStatsFor(id);
+                    yield return data.DeserializeGeneralStatsFor(id);
                 }
             }
         }

--- a/DragonFruit.Six.API/Data/GeneralStats.cs
+++ b/DragonFruit.Six.API/Data/GeneralStats.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 
 namespace DragonFruit.Six.API.Data
 {
-    public class Stats
+    public class GeneralStats
     {
         /// <summary>
         /// Profile Id

--- a/DragonFruit.Six.API/Data/Requests/Base/BasicStatsRequest.cs
+++ b/DragonFruit.Six.API/Data/Requests/Base/BasicStatsRequest.cs
@@ -10,22 +10,22 @@ namespace DragonFruit.Six.API.Data.Requests.Base
     /// <summary>
     /// Base for requesting general stats from the main endpoint
     /// </summary>
-    public class StatsRequestBase : PlatformSpecificRequest
+    public class BasicStatsRequest : PlatformSpecificRequest
     {
         public override string Path => Platform.StatsEndpoint();
 
         /// <summary>
-        /// Initialises a <see cref="StatsRequestBase"/> for a single <see cref="AccountInfo"/>
+        /// Initialises a <see cref="BasicStatsRequest"/> for a single <see cref="AccountInfo"/>
         /// </summary>
-        public StatsRequestBase(AccountInfo account)
+        public BasicStatsRequest(AccountInfo account)
             : base(new[] { account })
         {
         }
 
         /// <summary>
-        /// Initialises a <see cref="StatsRequestBase"/> for an array of <see cref="AccountInfo"/>s
+        /// Initialises a <see cref="BasicStatsRequest"/> for an array of <see cref="AccountInfo"/>s
         /// </summary>
-        public StatsRequestBase(IEnumerable<AccountInfo> accounts)
+        public BasicStatsRequest(IEnumerable<AccountInfo> accounts)
             : base(accounts)
         {
         }

--- a/DragonFruit.Six.API/Data/Requests/OperatorStatsRequest.cs
+++ b/DragonFruit.Six.API/Data/Requests/OperatorStatsRequest.cs
@@ -8,7 +8,7 @@ using DragonFruit.Six.API.Data.Strings;
 
 namespace DragonFruit.Six.API.Data.Requests
 {
-    public sealed class OperatorStatsRequest : StatsRequestBase
+    public sealed class OperatorStatsRequest : BasicStatsRequest
     {
         public OperatorStatsRequest(AccountInfo account, IEnumerable<OperatorStats> operators)
             : this(new[] { account }, operators)

--- a/DragonFruit.Six.API/Data/Requests/StatsRequest.cs
+++ b/DragonFruit.Six.API/Data/Requests/StatsRequest.cs
@@ -7,7 +7,7 @@ using DragonFruit.Six.API.Data.Strings;
 
 namespace DragonFruit.Six.API.Data.Requests
 {
-    public sealed class StatsRequest : StatsRequestBase
+    public sealed class StatsRequest : BasicStatsRequest
     {
         /// <summary>
         /// Initialises a request for all the stats in <see cref="Stats"/> for the provided <see cref="AccountInfo"/>

--- a/DragonFruit.Six.API/Data/Requests/WeaponStatsRequest.cs
+++ b/DragonFruit.Six.API/Data/Requests/WeaponStatsRequest.cs
@@ -7,7 +7,7 @@ using DragonFruit.Six.API.Data.Strings;
 
 namespace DragonFruit.Six.API.Data.Requests
 {
-    public sealed class WeaponStatsRequest : StatsRequestBase
+    public sealed class WeaponStatsRequest : BasicStatsRequest
     {
         public WeaponStatsRequest(AccountInfo account)
             : base(account)


### PR DESCRIPTION
Fixes the `GeneralStats` showing up as not found

Related to #187 