### PR TITLE
Fix broken perform overload

### DIFF
--- a/DragonFruit.Six.Api/Dragon6Client.cs
+++ b/DragonFruit.Six.Api/Dragon6Client.cs
@@ -70,11 +70,11 @@ namespace DragonFruit.Six.Api
         /// </summary>
         protected abstract TokenBase GetToken();
 
-        public T Perform<T>(UbiApiRequest requestData, CancellationToken cancellationToken, CancellationToken token = default) where T : class
+        public T Perform<T>(UbiApiRequest requestData, CancellationToken token = default) where T : class
         {
             lock (_lock)
             {
-                if (Token?.Expired != false)
+                if (Token is null || Token.Expired)
                 {
                     Token = GetToken();
                     ApplyToken(Token);

--- a/DragonFruit.Six.Api/Dragon6Client.cs
+++ b/DragonFruit.Six.Api/Dragon6Client.cs
@@ -76,6 +76,7 @@ namespace DragonFruit.Six.Api
             {
                 if (Token is null || Token.Expired)
                 {
+                    // todo throw something if this is majorly expired or null
                     Token = GetToken();
                     ApplyToken(Token);
                 }


### PR DESCRIPTION
I must have been lost when I wrote this...

This is the culprit behind http 500 errors the dragon6 servers have been facing. Current workaround was to purge the cache, and now i can see why that works

Note: if you only use the extensions this will make 0 impact, dragon6 uses its own custom requests that were being sent to the wrong overload