### PR TITLE
Add a clock skew safegard

### DIFF
--- a/DragonFruit.Six.Api.Tests/Data/AccountLookupTests.cs
+++ b/DragonFruit.Six.Api.Tests/Data/AccountLookupTests.cs
@@ -11,8 +11,9 @@ namespace DragonFruit.Six.Api.Tests.Data
     [TestFixture]
     public class AccountLookupTests : Dragon6ApiTest
     {
+        [TestCase("Curry.", LookupMethod.Name)]
         [TestCase("papa.curry", LookupMethod.Name)]
-        [TestCase("Frost_Bites_", LookupMethod.Name)]
+        [TestCase("PaPa.Yukina", LookupMethod.Name)]
         [TestCase("a5e7c9c4-a225-4d8e-810f-0c529d829a34", LookupMethod.UserId, Platform.PSN)]
         [TestCase("b6c8e00a-00f9-44fb-b83e-eb9135933b91", LookupMethod.UserId, Platform.XB1)]
         public void TestAccountLookup(string identifier, LookupMethod method, Platform platform = Platform.PC)

--- a/DragonFruit.Six.Api/Dragon6Client.cs
+++ b/DragonFruit.Six.Api/Dragon6Client.cs
@@ -18,8 +18,8 @@ namespace DragonFruit.Six.Api
 {
     public abstract class Dragon6Client : ApiClient
     {
-        public static readonly CultureInfo Culture = new("en-US", false);
         private readonly object _lock = new();
+        public static readonly CultureInfo Culture = new("en-US", false);
 
         #region Constructors
 

--- a/DragonFruit.Six.Api/Tokens/TokenBase.cs
+++ b/DragonFruit.Six.Api/Tokens/TokenBase.cs
@@ -8,6 +8,8 @@ namespace DragonFruit.Six.Api.Tokens
 {
     public abstract class TokenBase
     {
+        private DateTimeOffset? _safeExpiry;
+
         public abstract string Token { get; set; }
 
         public abstract DateTimeOffset Expiry { get; set; }
@@ -15,6 +17,9 @@ namespace DragonFruit.Six.Api.Tokens
         public virtual string SessionId { get; set; }
 
         [JsonIgnore]
-        public bool Expired => DateTimeOffset.Compare(DateTimeOffset.Now, Expiry) >= 0;
+        public bool Expired => InternalExpiry >= DateTimeOffset.Now;
+
+        [JsonIgnore]
+        private DateTimeOffset InternalExpiry => _safeExpiry ??= Expiry.AddMinutes(-5);
     }
 }

--- a/DragonFruit.Six.Api/Tokens/TokenBase.cs
+++ b/DragonFruit.Six.Api/Tokens/TokenBase.cs
@@ -10,11 +10,10 @@ namespace DragonFruit.Six.Api.Tokens
     {
         private DateTimeOffset? _safeExpiry;
 
-        public abstract string Token { get; set; }
-
-        public abstract DateTimeOffset Expiry { get; set; }
-
         public virtual string SessionId { get; set; }
+
+        public abstract string Token { get; set; }
+        public abstract DateTimeOffset Expiry { get; set; }
 
         [JsonIgnore]
         public bool Expired => InternalExpiry >= DateTimeOffset.Now;


### PR DESCRIPTION
Changes the `Expired` property of the token to return true when the token is within 5 mins of expiry. This will workaround any potential clock skews each side (client/ubisoft) could have.