### PR TITLE
prevent exceptions being thrown with new tokens

### DIFF
--- a/DragonFruit.Six.Api.Tests/Tokens/TokenExpiryTests.cs
+++ b/DragonFruit.Six.Api.Tests/Tokens/TokenExpiryTests.cs
@@ -1,0 +1,19 @@
+﻿// Dragon6 API Copyright 2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using DragonFruit.Six.Api.Tokens;
+using NUnit.Framework;
+
+namespace DragonFruit.Six.Api.Tests.Tokens
+{
+    [TestFixture]
+    public class TokenExpiryTests
+    {
+        [Test]
+        public void TestTokenExpiry()
+        {
+            var token = new Dragon6Token();
+            Assert.True(token.Expired);
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Tokens/Dragon6Token.cs
+++ b/DragonFruit.Six.Api/Tokens/Dragon6Token.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 namespace DragonFruit.Six.Api.Tokens
 {
     /// <summary>
-    /// The most basic implementation of <see cref="TokenBase"/>. Useful for storing the components that are actually needed
+    /// The most basic implementation of <see cref="TokenBase"/>.
     /// </summary>
     public class Dragon6Token : TokenBase
     {


### PR DESCRIPTION
this was the reason that the pc version was held back (microsoft rejected it because of this):

if we have a datetime of `01/01/0001 00:01:00 +00:00` and then try to use the old skewing system:
https://github.com/dragonfruitnetwork/dragon6-api/blob/d124aef321ef68c9adfa86a1b60e44af413032f1/DragonFruit.Six.Api/Tokens/TokenBase.cs#L21-L22

we would end up with... -5 minutes in a non-existent year. no surprise that causes an exception.
added a test to stop this kind of thing happening again