### PR TITLE
add mmr boundaries to RankInfo

### DIFF
--- a/DragonFruit.Six.Api.Tests/Utils/SeasonalRanksTests.cs
+++ b/DragonFruit.Six.Api.Tests/Utils/SeasonalRanksTests.cs
@@ -1,0 +1,32 @@
+﻿// Dragon6 API Copyright 2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using DragonFruit.Six.Api.Utils;
+using NUnit.Framework;
+
+namespace DragonFruit.Six.Api.Tests.Utils
+{
+    [TestFixture]
+    public class SeasonalRanksTests
+    {
+        [TestCase(5, 1)]
+        [TestCase(4000, 21)]
+        [TestCase(3012, 18)]
+        [TestCase(6050, 23)]
+        public void TestMMR(int mmr, byte expectedRankId)
+        {
+            var rank = SeasonalRanks.GetFromMMR(mmr);
+            Assert.AreEqual(expectedRankId, rank.Id);
+        }
+
+        [TestCase(-25, 1)]
+        [TestCase(3300, 17)]
+        [TestCase(4150, 19)]
+        [TestCase(4800, 20)]
+        public void TestLegacyMMR(int mmr, byte expectedRankId)
+        {
+            var rank = SeasonalRanks.GetFromMMR(mmr, true);
+            Assert.AreEqual(expectedRankId, rank.Id);
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Containers/RankInfo.cs
+++ b/DragonFruit.Six.Api/Containers/RankInfo.cs
@@ -7,11 +7,14 @@ namespace DragonFruit.Six.Api.Containers
 {
     public class RankInfo
     {
-        internal RankInfo(byte id, string name, string iconUrl)
+        internal RankInfo(byte id, string name, string iconUrl, int? minMMR, int? maxMMR)
         {
             Id = id;
             Name = name;
             IconUrl = iconUrl;
+
+            MinMMR = minMMR;
+            MaxMMR = maxMMR;
         }
 
         /// <summary>
@@ -31,5 +34,17 @@ namespace DragonFruit.Six.Api.Containers
         /// </summary>
         [JsonProperty("icon")]
         public string IconUrl { get; set; }
+
+        /// <summary>
+        /// The lower MMR boundary for this rank
+        /// </summary>
+        [JsonProperty("mmr_min")]
+        public int? MinMMR { get; set; }
+
+        /// <summary>
+        /// The upper MMR boudary for this rank
+        /// </summary>
+        [JsonProperty("mmr_max")]
+        public int? MaxMMR { get; set; }
     }
 }

--- a/DragonFruit.Six.Api/Entities/SeasonStats.cs
+++ b/DragonFruit.Six.Api/Entities/SeasonStats.cs
@@ -10,10 +10,11 @@ using Newtonsoft.Json;
 
 namespace DragonFruit.Six.Api.Entities
 {
+    [Serializable]
+    [JsonObject(MemberSerialization.OptIn)]
     public class SeasonStats : StatsBase, IAssociatedWithAccount, IStatsResponse
     {
-        private RankInfo _rankInfo;
-        private RankInfo _maxRankInfo;
+        private RankInfo _rankInfo, _maxRankInfo, _mmrRankInfo;
 
         [JsonProperty("profile")]
         internal string ProfileId { get; set; }
@@ -74,11 +75,10 @@ namespace DragonFruit.Six.Api.Entities
 
         #endregion
 
-        [JsonIgnore]
-        public RankInfo RankInfo => _rankInfo ??= SeasonId > 14 ? SeasonalRanks.Rank(Rank) : SeasonalRanks.Legacy(Rank);
-
-        [JsonIgnore]
-        public RankInfo MaxRankInfo => _maxRankInfo ??= SeasonId > 14 ? SeasonalRanks.Rank(MaxRank) : SeasonalRanks.Legacy(MaxRank);
+        public bool IsLegacySeason => SeasonId < 14;
+        public RankInfo RankInfo => _rankInfo ??= SeasonalRanks.GetFromId(Rank, IsLegacySeason);
+        public RankInfo MaxRankInfo => _maxRankInfo ??= SeasonalRanks.GetFromId(MaxRank, IsLegacySeason);
+        public RankInfo MMRRankInfo => _mmrRankInfo ??= SeasonalRanks.GetFromMMR((int)MMR, IsLegacySeason);
 
         public bool IsAssociatedWithAccount(AccountInfo account) => account.Identifiers.Profile.Equals(ProfileId);
     }

--- a/DragonFruit.Six.Api/Utils/SeasonalRanks.cs
+++ b/DragonFruit.Six.Api/Utils/SeasonalRanks.cs
@@ -1,6 +1,7 @@
 ﻿// Dragon6 API Copyright 2020 DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Please refer to the LICENSE file for more info
 
+using System.Linq;
 using DragonFruit.Six.Api.Containers;
 
 namespace DragonFruit.Six.Api.Utils
@@ -8,74 +9,93 @@ namespace DragonFruit.Six.Api.Utils
     public static class SeasonalRanks
     {
         /// <summary>
-        /// Gets the <see cref="RankInfo"/> for the user rank
+        /// Gets the <see cref="RankInfo"/> for the current rank based on id
         /// </summary>
-        public static RankInfo Rank(int rankId) => rankId switch
-        {
-            1 => new RankInfo(1, "Copper 5", "/rank/v2/1.svg"),
-            2 => new RankInfo(2, "Copper 4", "/rank/v2/2.svg"),
-            3 => new RankInfo(3, "Copper 3", "/rank/v2/3.svg"),
-            4 => new RankInfo(4, "Copper 2", "/rank/v2/4.svg"),
-            5 => new RankInfo(5, "Copper 1", "/rank/v2/5.svg"),
-
-            6 => new RankInfo(6, "Bronze 5", "/rank/v2/6.svg"),
-            7 => new RankInfo(7, "Bronze 4", "/rank/v2/7.svg"),
-            8 => new RankInfo(8, "Bronze 3", "/rank/v2/8.svg"),
-            9 => new RankInfo(9, "Bronze 2", "/rank/v2/9.svg"),
-            10 => new RankInfo(10, "Bronze 1", "/rank/v2/10.svg"),
-
-            11 => new RankInfo(11, "Silver 5", "/rank/v2/11.svg"),
-            12 => new RankInfo(12, "Silver 4", "/rank/v2/12.svg"),
-            13 => new RankInfo(13, "Silver 3", "/rank/v2/13.svg"),
-            14 => new RankInfo(14, "Silver 2", "/rank/v2/14.svg"),
-            15 => new RankInfo(15, "Silver 1", "/rank/v2/15.svg"),
-
-            16 => new RankInfo(16, "Gold 3", "/rank/v2/16.svg"),
-            17 => new RankInfo(17, "Gold 2", "/rank/v2/17.svg"),
-            18 => new RankInfo(18, "Gold 1", "/rank/v2/18.svg"),
-
-            19 => new RankInfo(19, "Platinum 3", "/rank/v2/19.svg"),
-            20 => new RankInfo(20, "Platinum 2", "/rank/v2/20.svg"),
-            21 => new RankInfo(21, "Platinum 1", "/rank/v2/21.svg"),
-
-            22 => new RankInfo(22, "Diamond", "/rank/v2/22.svg"),
-            23 => new RankInfo(23, "Champion", "/rank/v2/23.svg"),
-
-            _ => new RankInfo(0, "Unranked", "/rank/v2/0.svg")
-        };
+        public static RankInfo GetFromId(int rankId, bool legacy = false) => GetRank(rankId, legacy);
 
         /// <summary>
-        /// Gets the <see cref="RankInfo"/> for the user rank (pre-season 15)
+        /// Gets the <see cref="RankInfo"/> for the current rank based on the MMR value
         /// </summary>
-        public static RankInfo Legacy(int legacyRankId) => legacyRankId switch
+        public static RankInfo GetFromMMR(int mmr, bool legacy = false) => GetRank(mmr, legacy, true);
+
+        private static RankInfo GetRank(int identifier, bool isLegacyRanks = false, bool isMMR = false)
         {
-            1 => new RankInfo(1, "Copper 4", "/rank/v1/1.svg"),
-            2 => new RankInfo(2, "Copper 3", "/rank/v1/2.svg"),
-            3 => new RankInfo(3, "Copper 2", "/rank/v1/3.svg"),
-            4 => new RankInfo(4, "Copper 1", "/rank/v1/4.svg"),
+            var itemsSource = isLegacyRanks ? LegacyRanks : Ranks;
 
-            5 => new RankInfo(5, "Bronze 4", "/rank/v1/5.svg"),
-            6 => new RankInfo(6, "Bronze 3", "/rank/v1/6.svg"),
-            7 => new RankInfo(7, "Bronze 2", "/rank/v1/7.svg"),
-            8 => new RankInfo(8, "Bronze 1", "/rank/v1/8.svg"),
+            return isMMR switch
+            {
+                false => itemsSource.ElementAtOrDefault(identifier) ?? Ranks[0],
+                true => itemsSource.Where(x => (x.MinMMR ?? int.MinValue) <= identifier && (x.MaxMMR ?? int.MaxValue) >= identifier).OrderByDescending(x => x.Id).First()
+            };
+        }
 
-            9 => new RankInfo(9, "Silver 4", "/rank/v1/9.svg"),
-            10 => new RankInfo(10, "Silver 3", "/rank/v1/10.svg"),
-            11 => new RankInfo(11, "Silver 2", "/rank/v1/11.svg"),
-            12 => new RankInfo(12, "Silver 1", "/rank/v1/12.svg"),
+        #region Data Source
 
-            13 => new RankInfo(13, "Gold 4", "/rank/v1/13.svg"),
-            14 => new RankInfo(14, "Gold 3", "/rank/v1/14.svg"),
-            15 => new RankInfo(15, "Gold 2", "/rank/v1/15.svg"),
-            16 => new RankInfo(16, "Gold 1", "/rank/v1/16.svg"),
+        private static readonly RankInfo[] Ranks =
+        {
+            new(0, "Unranked", "/rank/v2/0.svg", null, null),
 
-            17 => new RankInfo(17, "Platinum 3", "/rank/v1/17.svg"),
-            18 => new RankInfo(18, "Platinum 2", "/rank/v1/18.svg"),
-            19 => new RankInfo(19, "Platinum 1", "/rank/v1/19.svg"),
+            new(1, "Copper 5", "/rank/v2/1.svg", null, 1199),
+            new(2, "Copper 4", "/rank/v2/2.svg", 1200, 1299),
+            new(3, "Copper 3", "/rank/v2/3.svg", 1300, 1399),
+            new(4, "Copper 2", "/rank/v2/4.svg", 1400, 1499),
+            new(5, "Copper 1", "/rank/v2/5.svg", 1500, 1599),
 
-            20 => new RankInfo(20, "Diamond", "/rank/v1/20.svg"),
+            new(6, "Bronze 5", "/rank/v2/6.svg", 1600, 1699),
+            new(7, "Bronze 4", "/rank/v2/7.svg", 1700, 1799),
+            new(8, "Bronze 3", "/rank/v2/8.svg", 1800, 1899),
+            new(9, "Bronze 2", "/rank/v2/9.svg", 1900, 1999),
+            new(10, "Bronze 1", "/rank/v2/10.svg", 2000, 2099),
 
-            _ => new RankInfo(0, "Unranked", "/rank/v1/0.svg")
+            new(11, "Silver 5", "/rank/v2/11.svg", 2100, 2199),
+            new(12, "Silver 4", "/rank/v2/12.svg", 2200, 2299),
+            new(13, "Silver 3", "/rank/v2/13.svg", 2300, 2399),
+            new(14, "Silver 2", "/rank/v2/14.svg", 2400, 2499),
+            new(15, "Silver 1", "/rank/v2/15.svg", 2500, 2599),
+
+            new(16, "Gold 3", "/rank/v2/16.svg", 2600, 2799),
+            new(17, "Gold 2", "/rank/v2/17.svg", 2800, 2999),
+            new(18, "Gold 1", "/rank/v2/18.svg", 3000, 3199),
+
+            new(19, "Platinum 3", "/rank/v2/19.svg", 3200, 3599),
+            new(20, "Platinum 2", "/rank/v2/20.svg", 3600, 3999),
+            new(21, "Platinum 1", "/rank/v2/21.svg", 4000, 4399),
+
+            new(22, "Diamond", "/rank/v2/22.svg", 4400, 4999),
+            new(23, "Champion", "/rank/v2/23.svg", 5000, null)
         };
+
+        private static readonly RankInfo[] LegacyRanks =
+        {
+            new(0, "Unranked", "/rank/v1/0.svg", null, null),
+
+            new(1, "Copper 4", "/rank/v1/1.svg", null, 1399),
+            new(2, "Copper 3", "/rank/v1/2.svg", 1400, 1499),
+            new(3, "Copper 2", "/rank/v1/3.svg", 1500, 1599),
+            new(4, "Copper 1", "/rank/v1/4.svg", 1600, 1699),
+
+            new(5, "Bronze 4", "/rank/v1/5.svg", 1700, 1799),
+            new(6, "Bronze 3", "/rank/v1/6.svg", 1800, 1899),
+            new(7, "Bronze 2", "/rank/v1/7.svg", 1900, 1999),
+            new(8, "Bronze 1", "/rank/v1/8.svg", 2000, 2099),
+
+            new(9, "Silver 4", "/rank/v1/9.svg", 2100, 2199),
+            new(10, "Silver 3", "/rank/v1/10.svg", 2200, 2299),
+            new(11, "Silver 2", "/rank/v1/11.svg", 2300, 2399),
+            new(12, "Silver 1", "/rank/v1/12.svg", 2400, 2499),
+
+            new(13, "Gold 4", "/rank/v1/13.svg", 2500, 2699),
+            new(14, "Gold 3", "/rank/v1/14.svg", 2700, 2899),
+            new(15, "Gold 2", "/rank/v1/15.svg", 2900, 3099),
+            new(16, "Gold 1", "/rank/v1/16.svg", 3100, 3299),
+
+            new(17, "Platinum 3", "/rank/v1/17.svg", 3300, 3699),
+            new(18, "Platinum 2", "/rank/v1/18.svg", 3700, 4099),
+            new(19, "Platinum 1", "/rank/v1/19.svg", 4100, 4499),
+
+            new(20, "Diamond", "/rank/v1/20.svg", 4500, null)
+        };
+
+        #endregion
     }
 }


### PR DESCRIPTION
Closes #247 by adding mmr boundaries. this does break current usages of the `SeasonalRanks` utility class.