### PR TITLE
Add base components for modern stats

### DIFF
--- a/DragonFruit.Six.Api.Tests/DragonFruit.Six.Api.Tests.csproj
+++ b/DragonFruit.Six.Api.Tests/DragonFruit.Six.Api.Tests.csproj
@@ -6,13 +6,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NUnit" Version="3.13.2"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.1.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
+        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\DragonFruit.Six.Api\DragonFruit.Six.Api.csproj"/>
+        <ProjectReference Include="..\DragonFruit.Six.Api\DragonFruit.Six.Api.csproj" />
     </ItemGroup>
 
 </Project>

--- a/DragonFruit.Six.Api/Accounts/Requests/UbisoftAccountRequest.cs
+++ b/DragonFruit.Six.Api/Accounts/Requests/UbisoftAccountRequest.cs
@@ -1,12 +1,13 @@
 ﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
+using System;
 using System.Collections.Generic;
 using DragonFruit.Data;
 using DragonFruit.Data.Parameters;
 using DragonFruit.Six.Api.Accounts.Enums;
-using DragonFruit.Six.Api.Accounts.Utils;
 using DragonFruit.Six.Api.Utils;
+using JetBrains.Annotations;
 
 namespace DragonFruit.Six.Api.Accounts.Requests
 {
@@ -48,15 +49,26 @@ namespace DragonFruit.Six.Api.Accounts.Requests
         /// </summary>
         public IEnumerable<string> Identifiers { get; set; }
 
+        [UsedImplicitly]
         [QueryParameter("platformType")]
-        private string PlatformValue => PlatformParser.PlatformIdentifierFor(Platform);
+        private string PlatformValue => Platform switch
+        {
+            Platform.PSN => "psn",
+            Platform.XB1 => "xbl",
+            Platform.PC => "uplay",
 
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        [UsedImplicitly]
         [QueryParameter("nameOnPlatform", CollectionConversionMode.Concatenated)]
         private IEnumerable<string> PlayerNames => LookupString(IdentifierType.Name);
 
+        [UsedImplicitly]
         [QueryParameter("idOnPlatform", CollectionConversionMode.Concatenated)]
         private IEnumerable<string> PlatformIds => LookupString(IdentifierType.PlatformId);
 
+        [UsedImplicitly]
         [QueryParameter("userId", CollectionConversionMode.Concatenated)]
         private IEnumerable<string> UbisoftIds => LookupString(IdentifierType.UserId);
 

--- a/DragonFruit.Six.Api/Accounts/Utils/PlatformParser.cs
+++ b/DragonFruit.Six.Api/Accounts/Utils/PlatformParser.cs
@@ -11,19 +11,6 @@ namespace DragonFruit.Six.Api.Accounts.Utils
     public static class PlatformParser
     {
         /// <summary>
-        /// <see cref="Platform"/> Identifier to Ubisoft string
-        /// </summary>
-        // todo move to reflecting EnumMember
-        public static string PlatformIdentifierFor(Platform platform) => platform switch
-        {
-            Platform.PSN => "psn",
-            Platform.XB1 => "xbl",
-            Platform.PC => "uplay",
-
-            _ => throw new ArgumentOutOfRangeException()
-        };
-
-        /// <summary>
         /// Enumerates over all <see cref="Platform"/>s, producing a <see cref="Dictionary{TKey,TValue}"/>
         /// of platforms to a user-defined value
         /// </summary>

--- a/DragonFruit.Six.Api/Authentication/Entities/ClientAccessToken.cs
+++ b/DragonFruit.Six.Api/Authentication/Entities/ClientAccessToken.cs
@@ -25,7 +25,12 @@ namespace DragonFruit.Six.Api.Authentication.Entities
         /// </summary>
         public void Inject(ApiRequest request)
         {
+            // all api requests need the ubi_v1 token
+            // this must be lowercase for the modern api to work
             request.WithAuthHeader($"ubi_v1 t={Token.Token}");
+
+            // modern api requests need botht the session id and the expiration headers added
+            request.WithHeader("Expiration", Token.Expiry.ToString("O"));
             request.WithHeader(UbisoftIdentifiers.UbiSessionIdHeader, Token.SessionId);
         }
     }

--- a/DragonFruit.Six.Api/Dragon6Client.cs
+++ b/DragonFruit.Six.Api/Dragon6Client.cs
@@ -59,6 +59,8 @@ namespace DragonFruit.Six.Api
             HttpStatusCode.Forbidden => throw new UbisoftErrorException(),
             HttpStatusCode.BadGateway => throw new UbisoftErrorException(),
 
+            HttpStatusCode.NoContent => default,
+
             _ => base.ValidateAndProcess<T>(response)
         };
 

--- a/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
+++ b/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
@@ -24,8 +24,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DragonFruit.Data" Version="2021.1218.0" />
-        <PackageReference Include="DragonFruit.Data.Serializers.Newtonsoft" Version="2021.1218.0" />
+        <PackageReference Include="DragonFruit.Data" Version="2021.1225.0" />
+        <PackageReference Include="DragonFruit.Data.Serializers.Newtonsoft" Version="2021.1225.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
     </ItemGroup>
 

--- a/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
+++ b/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
@@ -27,6 +27,7 @@
         <PackageReference Include="DragonFruit.Data" Version="2021.1225.0" />
         <PackageReference Include="DragonFruit.Data.Serializers.Newtonsoft" Version="2021.1225.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
+        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     </ItemGroup>
 
 </Project>

--- a/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
+++ b/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
@@ -16,6 +16,7 @@
         <RepositoryType>Git</RepositoryType>
         <RepositoryUrl>https://github.com/dragonfruitnetwork/dragon6-api</RepositoryUrl>
         <PackageProjectUrl>https://github.com/dragonfruitnetwork/dragon6-api</PackageProjectUrl>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
+++ b/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
@@ -19,12 +19,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\res\icon.png" Pack="true" PackagePath="."/>
+        <None Include="..\res\icon.png" Pack="true" PackagePath="." />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DragonFruit.Data" Version="2021.1218.0"/>
-        <PackageReference Include="DragonFruit.Data.Serializers.Newtonsoft" Version="2021.1218.0"/>
+        <PackageReference Include="DragonFruit.Data" Version="2021.1218.0" />
+        <PackageReference Include="DragonFruit.Data.Serializers.Newtonsoft" Version="2021.1218.0" />
+        <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
     </ItemGroup>
 
 </Project>

--- a/DragonFruit.Six.Api/Endpoints.cs
+++ b/DragonFruit.Six.Api/Endpoints.cs
@@ -6,7 +6,7 @@ using DragonFruit.Six.Api.Accounts.Enums;
 
 namespace DragonFruit.Six.Api
 {
-    public static class Endpoints
+    internal static class Endpoints
     {
         /// <summary>
         /// Public API endpoint
@@ -21,7 +21,7 @@ namespace DragonFruit.Six.Api
         /// <summary>
         /// Url of the platform-specific "sandbox", the place where all the stats are acquired from
         /// </summary>
-        private static string SandboxUrlFor(this Platform platform) => $"{BaseEndpoint}/v1/spaces/{platform.GameSpaceId()}/sandboxes" + platform switch
+        public static string SandboxUrl(this Platform platform) => $"{BaseEndpoint}/v1/spaces/{platform.GameSpaceId()}/sandboxes" + platform switch
         {
             Platform.PSN => "/OSBOR_PS4_LNCH_A",
             Platform.XB1 => "/OSBOR_XBOXONE_LNCH_A",
@@ -29,9 +29,5 @@ namespace DragonFruit.Six.Api
 
             _ => throw new ArgumentOutOfRangeException()
         };
-
-        public static string StatsEndpoint(this Platform platform) => $"{SandboxUrlFor(platform)}/playerstats2/statistics";
-        public static string SeasonalStatsEndpoint(this Platform platform) => $"{SandboxUrlFor(platform)}/r6karma/players";
-        public static string ProfileStatsEndpoint(this Platform platform) => $"{SandboxUrlFor(platform)}/r6playerprofile/playerprofile/progressions";
     }
 }

--- a/DragonFruit.Six.Api/Legacy/Requests/LegacyStatsRequest.cs
+++ b/DragonFruit.Six.Api/Legacy/Requests/LegacyStatsRequest.cs
@@ -16,7 +16,7 @@ namespace DragonFruit.Six.Api.Legacy.Requests
     {
         private IEnumerable<string> _stats;
 
-        public override string Path => Platform.StatsEndpoint();
+        public override string Path => $"{Platform.SandboxUrl()}/playerstats2/statistics";
 
         /// <summary>
         /// Initialises a <see cref="LegacyStatsRequest"/> for an array of <see cref="UbisoftAccount"/>s

--- a/DragonFruit.Six.Api/Legacy/Requests/PlayerLevelStatsRequest.cs
+++ b/DragonFruit.Six.Api/Legacy/Requests/PlayerLevelStatsRequest.cs
@@ -10,7 +10,7 @@ namespace DragonFruit.Six.Api.Legacy.Requests
 {
     public class PlayerLevelStatsRequest : PlatformSpecificRequest
     {
-        public override string Path => Platform.ProfileStatsEndpoint();
+        public override string Path => $"{Platform.SandboxUrl()}/r6playerprofile/playerprofile/progressions";
 
         public PlayerLevelStatsRequest(IEnumerable<UbisoftAccount> accounts)
             : base(accounts)

--- a/DragonFruit.Six.Api/Modern/Containers/ModernModeStatsContainer.cs
+++ b/DragonFruit.Six.Api/Modern/Containers/ModernModeStatsContainer.cs
@@ -1,0 +1,38 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System;
+using DragonFruit.Six.Api.Modern.Enums;
+using DragonFruit.Six.Api.Modern.Utils;
+using Newtonsoft.Json;
+
+namespace DragonFruit.Six.Api.Modern.Containers
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    [JsonConverter(typeof(JsonPathConverter))]
+    public class ModernModeStatsContainer<T>
+    {
+        [JsonIgnore]
+        public ModernRoleStatsContainer<T> this[PlaylistType type] => type switch
+        {
+            PlaylistType.All => AllModes,
+            PlaylistType.Casual => Casual,
+            PlaylistType.Ranked => Ranked,
+            PlaylistType.Unranked => Unranked,
+
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+        };
+
+        [JsonProperty("gameModes.all")]
+        public ModernRoleStatsContainer<T> AllModes { get; set; }
+
+        [JsonProperty("gameModes.casual")]
+        public ModernRoleStatsContainer<T> Casual { get; set; }
+
+        [JsonProperty("gameModes.ranked")]
+        public ModernRoleStatsContainer<T> Ranked { get; set; }
+
+        [JsonProperty("gameModes.unranked")]
+        public ModernRoleStatsContainer<T> Unranked { get; set; }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Containers/ModernRoleStatsContainer.cs
+++ b/DragonFruit.Six.Api/Modern/Containers/ModernRoleStatsContainer.cs
@@ -1,0 +1,33 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System;
+using DragonFruit.Six.Api.Enums;
+using DragonFruit.Six.Api.Modern.Utils;
+using Newtonsoft.Json;
+
+namespace DragonFruit.Six.Api.Modern.Containers
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    [JsonConverter(typeof(JsonPathConverter))]
+    public class ModernRoleStatsContainer<T>
+    {
+        public T this[OperatorType type] => type switch
+        {
+            OperatorType.Independent => AsAny,
+            OperatorType.Attacker => AsAttacker,
+            OperatorType.Defender => AsDefender,
+
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+        };
+
+        [JsonProperty("teamRoles.all")]
+        public T AsAny { get; set; }
+
+        [JsonProperty("teamRoles.attacker")]
+        public T AsAttacker { get; set; }
+
+        [JsonProperty("teamRoles.defender")]
+        public T AsDefender { get; set; }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Containers/ModernStatsTrendPeriod.cs
+++ b/DragonFruit.Six.Api/Modern/Containers/ModernStatsTrendPeriod.cs
@@ -1,0 +1,33 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace DragonFruit.Six.Api.Modern.Containers
+{
+    public class ModernStatsTrendPeriod<T>
+    {
+        private readonly string _dateRange;
+
+        private DateTime? _start, _end;
+        private IEnumerable<string> _periods;
+
+        public ModernStatsTrendPeriod(string dateRange, T value)
+        {
+            _dateRange = dateRange;
+            Value = value;
+        }
+
+        public T Value { get; set; }
+
+        public DateTime Start => _start ??= ParsePeriodDate(Periods.First());
+        public DateTime End => _end ??= ParsePeriodDate(Periods.Last());
+
+        private IEnumerable<string> Periods => _periods ??= _dateRange.Split(':');
+
+        private static DateTime ParsePeriodDate(string date) => DateTime.ParseExact(date, "yyyy-MM-dd", null, DateTimeStyles.AssumeUniversal);
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Containers/WeaponGroup.cs
+++ b/DragonFruit.Six.Api/Modern/Containers/WeaponGroup.cs
@@ -1,0 +1,19 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System.Collections.Generic;
+using DragonFruit.Six.Api.Modern.Entities;
+using Newtonsoft.Json;
+
+namespace DragonFruit.Six.Api.Modern.Containers
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class WeaponGroup
+    {
+        [JsonProperty("weaponType")]
+        public string Type { get; set; }
+
+        [JsonProperty("weapons")]
+        public IEnumerable<ModernWeaponStats> Weapons { get; set; }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Containers/WeaponSlot.cs
+++ b/DragonFruit.Six.Api/Modern/Containers/WeaponSlot.cs
@@ -1,0 +1,20 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System.Collections.Generic;
+using DragonFruit.Six.Api.Modern.Utils;
+using Newtonsoft.Json;
+
+namespace DragonFruit.Six.Api.Modern.Containers
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    [JsonConverter(typeof(JsonPathConverter))]
+    public class WeaponSlot
+    {
+        [JsonProperty("weaponSlots.primaryWeapons.weaponTypes")]
+        public IEnumerable<WeaponGroup> Primary { get; set; }
+
+        [JsonProperty("weaponSlots.secondaryWeapons.weaponTypes")]
+        public IEnumerable<WeaponGroup> Secondary { get; set; }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Entities/ModernMapStats.cs
+++ b/DragonFruit.Six.Api/Modern/Entities/ModernMapStats.cs
@@ -1,0 +1,9 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+namespace DragonFruit.Six.Api.Modern.Entities
+{
+    public class ModernMapStats : ModernStatsBase
+    {
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Entities/ModernOperatorStats.cs
+++ b/DragonFruit.Six.Api/Modern/Entities/ModernOperatorStats.cs
@@ -1,0 +1,9 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+namespace DragonFruit.Six.Api.Modern.Entities
+{
+    public class ModernOperatorStats : ModernStatsBase
+    {
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Entities/ModernSeasonStats.cs
+++ b/DragonFruit.Six.Api/Modern/Entities/ModernSeasonStats.cs
@@ -1,0 +1,24 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+
+namespace DragonFruit.Six.Api.Modern.Entities
+{
+    public class ModernSeasonStats : ModernStatsBase
+    {
+        [JsonProperty("seasonYear")]
+        public string Year { get; set; }
+
+        [JsonProperty("seasonNumber")]
+        public string SeasonNumber { get; set; }
+
+        [OnDeserialized]
+        internal void OnDeserialized(StreamingContext context)
+        {
+            // override the default season as it will always be "summary"
+            Name = $"{Year}{SeasonNumber}";
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Entities/ModernStatsBase.cs
+++ b/DragonFruit.Six.Api/Modern/Entities/ModernStatsBase.cs
@@ -1,0 +1,157 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System;
+using DragonFruit.Six.Api.Modern.Utils;
+using DragonFruit.Six.Api.Utils;
+using Newtonsoft.Json;
+
+namespace DragonFruit.Six.Api.Modern.Entities
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    [JsonConverter(typeof(JsonPathConverter))]
+    public abstract class ModernStatsBase
+    {
+        private float? _roundWl, _matchWl, _kd;
+        private TimeSpan? _timePlayed, _timeAlivePerMatch, _timeDeadPerMatch;
+
+        [JsonProperty("statsDetail")]
+        public string Name { get; set; }
+
+        #region Match Stats
+
+        [JsonProperty("matchesWon")]
+        public uint MatchesWon { get; set; }
+
+        [JsonProperty("matchesLost")]
+        public uint MatchesLost { get; set; }
+
+        [JsonProperty("matchesPlayed")]
+        public uint MatchesPlayed { get; set; }
+
+        public float MatchWl => _matchWl ??= RatioUtils.RatioOf(MatchesWon, MatchesLost);
+
+        #endregion
+
+        #region Round Stats
+
+        [JsonProperty("roundsPlayed")]
+        public uint RoundsPlayed { get; set; }
+
+        [JsonProperty("roundsWon")]
+        public uint RoundsWon { get; set; }
+
+        [JsonProperty("roundsLost")]
+        public uint RoundsLost { get; set; }
+
+        public float RoundWl => _roundWl ??= RatioUtils.RatioOf(RoundsWon, RoundsLost);
+
+        #endregion
+
+        #region Kill/Deaths
+
+        [JsonProperty("kills")]
+        public uint Kills { get; set; }
+
+        [JsonProperty("assists")]
+        public uint Assists { get; set; }
+
+        [JsonProperty("death")]
+        public uint Deaths { get; set; }
+
+        [JsonProperty("headshots")]
+        public uint Headshots { get; set; }
+
+        [JsonProperty("meleeKills")]
+        public uint Knifes { get; set; }
+
+        [JsonProperty("teamKills")]
+        public uint TeamKills { get; set; }
+
+        [JsonProperty("openingKills")]
+        public uint OpeningKills { get; set; }
+
+        [JsonProperty("openingDeaths")]
+        public uint OpeningDeaths { get; set; }
+
+        [JsonProperty("trades")]
+        public uint Trades { get; set; }
+
+        [JsonProperty("revives")]
+        public uint Revives { get; set; }
+
+        [JsonProperty("openingKillTrades")]
+        public uint OpeningKillTrades { get; set; }
+
+        [JsonProperty("openingDeathTrades")]
+        public uint OpeningDeathTrades { get; set; }
+
+        #endregion
+
+        #region Distance Stats
+
+        [JsonProperty("distanceTravelled")]
+        public float DistanceTravelled { get; set; }
+
+        [JsonProperty("distancePerRound")]
+        public float DistanceTravelledPerRound { get; set; }
+
+        #endregion
+
+        #region Time Played
+
+        [JsonProperty("timeAlivePerMatch")]
+        public float SecondsAlivePerMatch { get; set; }
+
+        [JsonProperty("timeDeadPerMatch")]
+        public float SecondsDeadPerMatch { get; set; }
+
+        [JsonProperty("minutesPlayed")]
+        public float MinutesPlayed { get; set; }
+
+        public TimeSpan TimeAlivePerMatch => _timeAlivePerMatch ??= TimeSpan.FromSeconds(SecondsAlivePerMatch);
+        public TimeSpan TimeDeadPerMatch => _timeDeadPerMatch ??= TimeSpan.FromSeconds(SecondsDeadPerMatch);
+        public TimeSpan TimePlayed => _timePlayed ??= TimeSpan.FromMinutes(MinutesPlayed);
+
+        #endregion
+
+        #region Ratios
+
+        [JsonProperty("headshotAccuracy.value")]
+        public float HeadshotAccuracy { get; set; }
+
+        [JsonProperty("killsPerRound.value")]
+        public float KillsPerRound { get; set; }
+
+        [JsonProperty("roundsWithAKill.value")]
+        public float RoundsWithSingleKill { get; set; }
+
+        [JsonProperty("roundsWithMultiKill.value")]
+        public float RoundsWithMultipleKills { get; set; }
+
+        [JsonProperty("roundsWithOpeningKill.value")]
+        public float RoundsWithFirstKill { get; set; }
+
+        [JsonProperty("roundsWithOpeningDeath.value")]
+        public float RoundsWithFirstDeath { get; set; }
+
+        [JsonProperty("roundsSurvived.value")]
+        public float RoundsSurvived { get; set; }
+
+        [JsonProperty("roundsWithAnAce.value")]
+        public float RoundsAced { get; set; }
+
+        [JsonProperty("roundsWithClutch.value")]
+        public float RoundsClutched { get; set; }
+
+        /// <summary>
+        /// Rounds with a kill, objective completion, survive or trade kills
+        /// </summary>
+        [JsonProperty("roundsWithKOST.value")]
+        public float RoundsWithKillObjectiveSurvivalOrTrade { get; set; }
+
+        public float Kd => _kd ??= RatioUtils.RatioOf(Kills, Deaths);
+
+        #endregion
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Entities/ModernStatsSummary.cs
+++ b/DragonFruit.Six.Api/Modern/Entities/ModernStatsSummary.cs
@@ -1,0 +1,9 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+namespace DragonFruit.Six.Api.Modern.Entities
+{
+    public class ModernStatsSummary : ModernStatsBase
+    {
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Entities/ModernStatsTrend.cs
+++ b/DragonFruit.Six.Api/Modern/Entities/ModernStatsTrend.cs
@@ -1,0 +1,147 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System.Collections.Generic;
+using System.Linq;
+using DragonFruit.Six.Api.Modern.Containers;
+using Newtonsoft.Json;
+
+namespace DragonFruit.Six.Api.Modern.Entities
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class ModernStatsTrend
+    {
+        [JsonProperty("statsPeriod")]
+        public string[] StatsPeriods { get; set; }
+
+        #region Matches/Rounds
+
+        [JsonProperty("matchesPlayed")]
+        public int[] MatchesPlayed { get; set; }
+
+        [JsonProperty("roundsPlayed")]
+        public int[] RoundsPlayed { get; set; }
+
+        [JsonProperty("minutesPlayed")]
+        public int[] MinutesPlayed { get; set; }
+
+        [JsonProperty("matchesWon")]
+        public int[] MatchesWon { get; set; }
+
+        [JsonProperty("matchesLost")]
+        public int[] MatchesLost { get; set; }
+
+        [JsonProperty("roundsWon")]
+        public int[] RoundsWon { get; set; }
+
+        [JsonProperty("roundsLost")]
+        public int[] RoundsLost { get; set; }
+
+        #endregion
+
+        #region Kills/Deaths
+
+        [JsonProperty("kills")]
+        public int[] Kills { get; set; }
+
+        [JsonProperty("assists")]
+        public int[] Assists { get; set; }
+
+        [JsonProperty("death")]
+        public int[] Deaths { get; set; }
+
+        [JsonProperty("headshots")]
+        public int[] Headshots { get; set; }
+
+        [JsonProperty("meleeKills")]
+        public int[] MeleeKills { get; set; }
+
+        [JsonProperty("teamKills")]
+        public int[] TeamKills { get; set; }
+
+        [JsonProperty("openingKills")]
+        public int[] OpeningKills { get; set; }
+
+        [JsonProperty("openingDeaths")]
+        public int[] OpeningDeaths { get; set; }
+
+        [JsonProperty("trades")]
+        public int[] Trades { get; set; }
+
+        [JsonProperty("openingKillTrades")]
+        public int[] OpeningKillTrades { get; set; }
+
+        [JsonProperty("openingDeathTrades")]
+        public int[] OpeningDeathTrades { get; set; }
+
+        [JsonProperty("revives")]
+        public int[] Revives { get; set; }
+
+        #endregion
+
+        #region Ratios
+
+        [JsonProperty("winLossRatio")]
+        public float[] Wl { get; set; }
+
+        [JsonProperty("killDeathRatio")]
+        public float[] Kd { get; set; }
+
+        [JsonProperty("headshotAccuracy")]
+        public float[] HeadshotAccuracy { get; set; }
+
+        [JsonProperty("killsPerRound")]
+        public float[] KillsPerRound { get; set; }
+
+        #endregion
+
+        #region Rounds (Extended Info)
+
+        [JsonProperty("roundsWithAKill")]
+        public float[] RoundsWithAKill { get; set; }
+
+        [JsonProperty("roundsWithMultiKill")]
+        public float[] RoundsWithMultiKill { get; set; }
+
+        [JsonProperty("roundsWithOpeningKill")]
+        public float[] RoundsWithOpeningKill { get; set; }
+
+        [JsonProperty("roundsWithOpeningDeath")]
+        public float[] RoundsWithOpeningDeath { get; set; }
+
+        [JsonProperty("roundsWithKOST")]
+        public float[] RoundsWithKost { get; set; }
+
+        [JsonProperty("roundsSurvived")]
+        public float[] RoundsSurvived { get; set; }
+
+        [JsonProperty("roundsWithAnAce")]
+        public float[] RoundsWithAnAce { get; set; }
+
+        [JsonProperty("roundsWithClutch")]
+        public int[] RoundsWithClutch { get; set; }
+
+        #endregion
+
+        #region Time/Distance
+
+        [JsonProperty("timeAlivePerMatch")]
+        public float[] TimeAlivePerMatch { get; set; }
+
+        [JsonProperty("timeDeadPerMatch")]
+        public float[] TimeDeadPerMatch { get; set; }
+
+        [JsonProperty("distanceTravelled")]
+        public int[] DistanceTravelled { get; set; }
+
+        [JsonProperty("distancePerRound")]
+        public float[] DistancePerRound { get; set; }
+
+        #endregion
+
+        public IEnumerable<ModernStatsTrendPeriod<T>> Collate<T>(IEnumerable<T> data)
+        {
+            return StatsPeriods.Zip(data, (period, values) => new ModernStatsTrendPeriod<T>(period, values));
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Entities/ModernWeaponStats.cs
+++ b/DragonFruit.Six.Api/Modern/Entities/ModernWeaponStats.cs
@@ -1,0 +1,49 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using DragonFruit.Six.Api.Utils;
+using Newtonsoft.Json;
+
+namespace DragonFruit.Six.Api.Modern.Entities
+{
+    /// <summary>
+    /// Object containing stats for a specific weapon
+    /// </summary>
+    /// <remarks>
+    /// Wins/Losses are recorded per round
+    /// </remarks>
+    [JsonObject(MemberSerialization.OptIn)]
+    public class ModernWeaponStats
+    {
+        private float? _wl;
+
+        [JsonProperty("weaponName")]
+        public string Name { get; set; }
+
+        [JsonProperty("kills")]
+        public uint Kills { get; set; }
+
+        [JsonProperty("headshots")]
+        public uint Headshots { get; set; }
+
+        [JsonProperty("headshotAccuracy")]
+        public float HeadshotAccuracy { get; set; }
+
+        [JsonProperty("roundsWon")]
+        public uint Wins { get; set; }
+
+        [JsonProperty("roundsLost")]
+        public uint Losses { get; set; }
+
+        [JsonProperty("roundsPlayed")]
+        public uint RoundsPlayed { get; set; }
+
+        [JsonProperty("roundsWithAKill")]
+        public float RoundsWithSingleKill { get; set; }
+
+        [JsonProperty("roundsWithAMultiKill")]
+        public float RoundsWithMultipleKills { get; set; }
+
+        public float Wl => _wl ??= RatioUtils.RatioOf(Wins, Losses);
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Enums/PlaylistType.cs
+++ b/DragonFruit.Six.Api/Modern/Enums/PlaylistType.cs
@@ -8,10 +8,10 @@ namespace DragonFruit.Six.Api.Modern.Enums
     [Flags]
     public enum PlaylistType
     {
-        Casual,
-        Ranked,
-        Unranked,
+        Casual = 1 << 0,
+        Ranked = 1 << 1,
+        Unranked = 1 << 2,
 
-        All
+        All = 1 << 3
     }
 }

--- a/DragonFruit.Six.Api/Modern/Enums/PlaylistType.cs
+++ b/DragonFruit.Six.Api/Modern/Enums/PlaylistType.cs
@@ -1,0 +1,17 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using System;
+
+namespace DragonFruit.Six.Api.Modern.Enums
+{
+    [Flags]
+    public enum PlaylistType
+    {
+        Casual,
+        Ranked,
+        Unranked,
+
+        All
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Enums/TrendSpan.cs
+++ b/DragonFruit.Six.Api/Modern/Enums/TrendSpan.cs
@@ -1,0 +1,10 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+namespace DragonFruit.Six.Api.Modern.Enums
+{
+    public enum TrendSpan
+    {
+        Weekly
+    }
+}

--- a/DragonFruit.Six.Api/Modern/ModernStatsDeserializer.cs
+++ b/DragonFruit.Six.Api/Modern/ModernStatsDeserializer.cs
@@ -1,0 +1,22 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using DragonFruit.Six.Api.Modern.Containers;
+using DragonFruit.Six.Api.Modern.Requests;
+using DragonFruit.Six.Api.Modern.Utils;
+using Newtonsoft.Json.Linq;
+
+namespace DragonFruit.Six.Api.Modern
+{
+    public static class ModernStatsDeserializer
+    {
+        /// <summary>
+        /// Abstracts a ubisoft stats response to present the data required
+        /// </summary>
+        public static ModernModeStatsContainer<T> ProcessData<T>(this JObject source, ModernStatsRequest request)
+        {
+            var data = source?["platforms"]?[request.Account.Platform.ModernName()];
+            return data?.ToObject<ModernModeStatsContainer<T>>();
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/ModernStatsExtensions.cs
+++ b/DragonFruit.Six.Api/Modern/ModernStatsExtensions.cs
@@ -1,0 +1,107 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DragonFruit.Six.Api.Accounts.Entities;
+using DragonFruit.Six.Api.Enums;
+using DragonFruit.Six.Api.Modern.Containers;
+using DragonFruit.Six.Api.Modern.Entities;
+using DragonFruit.Six.Api.Modern.Enums;
+using DragonFruit.Six.Api.Modern.Requests;
+using DragonFruit.Six.Api.Modern.Utils;
+using Newtonsoft.Json.Linq;
+
+namespace DragonFruit.Six.Api.Modern
+{
+    public static class ModernStatsExtensions
+    {
+        public static Task<ModernModeStatsContainer<IEnumerable<ModernMapStats>>> GetModernMapStatsAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, OperatorType operatorType = OperatorType.Independent, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null)
+        {
+            var request = new ModernMapStatsRequest(account)
+            {
+                Playlist = playlistType,
+                OperatorType = operatorType
+            };
+
+            ValueUtils.ApplyValue(startDate, s => request.StartDate = s);
+            ValueUtils.ApplyValue(endDate, e => request.EndDate = e);
+
+            return client.PerformAsync<JObject>(request)
+                         .ContinueWith(t => t.Result.ProcessData<IEnumerable<ModernMapStats>>(request), TaskContinuationOptions.OnlyOnRanToCompletion);
+        }
+
+        public static Task<ModernModeStatsContainer<IEnumerable<ModernOperatorStats>>> GetModernOperatorStatsAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, OperatorType operatorType = OperatorType.Independent, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null)
+        {
+            var request = new ModernOperatorStatsRequest(account)
+            {
+                Playlist = playlistType,
+                OperatorType = operatorType
+            };
+
+            ValueUtils.ApplyValue(startDate, s => request.StartDate = s);
+            ValueUtils.ApplyValue(endDate, e => request.EndDate = e);
+
+            return client.PerformAsync<JObject>(request)
+                         .ContinueWith(t => t.Result.ProcessData<IEnumerable<ModernOperatorStats>>(request), TaskContinuationOptions.OnlyOnRanToCompletion);
+        }
+
+        public static Task<ModernModeStatsContainer<IEnumerable<ModernSeasonStats>>> GetModernSeasonStatsAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All)
+        {
+            var request = new ModernSeasonalStatsRequest(account)
+            {
+                Playlist = playlistType
+            };
+
+            return client.PerformAsync<JObject>(request)
+                         .ContinueWith(t => t.Result.ProcessData<IEnumerable<ModernSeasonStats>>(request), TaskContinuationOptions.OnlyOnRanToCompletion);
+        }
+
+        public static Task<ModernModeStatsContainer<IEnumerable<ModernStatsSummary>>> GetModernStatsSummaryAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, OperatorType operatorType = OperatorType.Independent, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null)
+        {
+            var request = new ModernStatsSummaryRequest(account)
+            {
+                Playlist = playlistType,
+                OperatorType = operatorType
+            };
+
+            ValueUtils.ApplyValue(startDate, s => request.StartDate = s);
+            ValueUtils.ApplyValue(endDate, e => request.EndDate = e);
+
+            return client.PerformAsync<JObject>(request)
+                         .ContinueWith(t => t.Result.ProcessData<IEnumerable<ModernStatsSummary>>(request), TaskContinuationOptions.OnlyOnRanToCompletion);
+        }
+
+        public static Task<ModernModeStatsContainer<IEnumerable<ModernStatsTrend>>> GetModernStatsTrendAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, OperatorType operatorType = OperatorType.Independent, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null)
+        {
+            var request = new ModernStatsTrendRequest(account)
+            {
+                Playlist = playlistType,
+                OperatorType = operatorType,
+                TrendSpan = TrendSpan.Weekly
+            };
+
+            ValueUtils.ApplyValue(startDate, s => request.StartDate = s);
+            ValueUtils.ApplyValue(endDate, e => request.EndDate = e);
+
+            return client.PerformAsync<JObject>(request)
+                         .ContinueWith(t => t.Result.ProcessData<IEnumerable<ModernStatsTrend>>(request), TaskContinuationOptions.OnlyOnRanToCompletion);
+        }
+
+        public static Task<ModernModeStatsContainer<WeaponSlot>> GetModernWeaponStatsAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, OperatorType operatorType = OperatorType.Independent, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null)
+        {
+            var request = new ModernWeaponStatsRequest(account)
+            {
+                Playlist = playlistType,
+                OperatorType = operatorType
+            };
+
+            ValueUtils.ApplyValue(startDate, s => request.StartDate = s);
+            ValueUtils.ApplyValue(endDate, e => request.EndDate = e);
+
+            return client.PerformAsync<JObject>(request)
+                         .ContinueWith(t => t.Result.ProcessData<WeaponSlot>(request), TaskContinuationOptions.OnlyOnRanToCompletion);
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/ModernStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/ModernStatsRequest.cs
@@ -125,7 +125,7 @@ namespace DragonFruit.Six.Api.Modern
 
         [UsedImplicitly]
         [QueryParameter("teamRole")]
-        protected virtual string OperatorTypeNames => OperatorType.HasFlag(OperatorType.Independent)
+        protected virtual string OperatorTypeNames => OperatorType.HasFlagFast(OperatorType.Independent)
             // independent = all
             ? (OperatorType.Attacker | OperatorType.Defender).Expand() + ",all"
             // here we remove the independent flag then expand

--- a/DragonFruit.Six.Api/Modern/ModernStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/ModernStatsRequest.cs
@@ -1,0 +1,134 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using System;
+using DragonFruit.Data.Parameters;
+using DragonFruit.Six.Api.Accounts.Entities;
+using DragonFruit.Six.Api.Accounts.Enums;
+using DragonFruit.Six.Api.Enums;
+using DragonFruit.Six.Api.Modern.Enums;
+using DragonFruit.Six.Api.Modern.Utils;
+using JetBrains.Annotations;
+
+namespace DragonFruit.Six.Api.Modern
+{
+    public abstract class ModernStatsRequest : UbiApiRequest
+    {
+        private const string DateTimeFormat = "yyyyMMdd";
+        private const int DefaultStartWindow = 14;
+
+        private PlaylistType? _playlist;
+        private OperatorType? _operatorType;
+        private DateTimeOffset? _startDate, _endDate;
+
+        public override string Path => $"https://r6s-stats.ubisoft.com/v1/{RequestCategory}/{RequestType}/{Account.ProfileId}";
+
+        protected ModernStatsRequest(UbisoftAccount account)
+        {
+            Account = account ?? throw new NullReferenceException();
+        }
+
+        /// <summary>
+        /// The category the request fits in (i.e. current, seasonal, narrative, etc.)
+        /// </summary>
+        protected virtual string RequestCategory => "current";
+
+        /// <summary>
+        /// The type of request (general, operators, weapons, etc.)
+        /// </summary>
+        /// <remarks>
+        /// This is the string included in the uri
+        /// </remarks>
+        protected abstract string RequestType { get; }
+
+        /// <summary>
+        /// The account to get stats for
+        /// </summary>
+        public UbisoftAccount Account { get; }
+
+        /// <summary>
+        /// The <see cref="PlaylistType"/> to get stats for (as a bitwise flag)
+        /// </summary>
+        public PlaylistType Playlist
+        {
+            get => _playlist ??= PlaylistType.Ranked | PlaylistType.Casual | PlaylistType.Unranked;
+            set => _playlist = value;
+        }
+
+        /// <summary>
+        /// Option to filter stats based on whether they were accumulated during an attack or defense round.
+        /// </summary>
+        public virtual OperatorType OperatorType
+        {
+            get => _operatorType ??= OperatorType.Independent;
+            set => _operatorType = value;
+        }
+
+        /// <summary>
+        /// The start date for the stats
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">The date provided was more than 120 days ago</exception>
+        public virtual DateTimeOffset StartDate
+        {
+            get => _startDate ??= DateTimeOffset.Now.AddDays(-DefaultStartWindow);
+            set
+            {
+                if (DateTimeOffset.UtcNow.Date.AddDays(-120) > value.Date)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(StartDate), "Date provided was more than 120 days ago. Stats are only held for upto 120 days before being removed");
+                }
+
+                _startDate = value;
+            }
+        }
+
+        /// <summary>
+        /// The end date for the stats
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">The date provided is in the future</exception>
+        public virtual DateTimeOffset EndDate
+        {
+            get => _endDate ??= DateTimeOffset.Now;
+            set
+            {
+                if (DateTimeOffset.UtcNow.Date > value.Date)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(EndDate), "Date provided was in the future");
+                }
+
+                _endDate = value;
+            }
+        }
+
+        [UsedImplicitly]
+        [QueryParameter("platform")]
+        private string PlatformName => Account.Platform switch
+        {
+            Platform.PC => "PC",
+            Platform.PSN => "PSN",
+            Platform.XB1 => "XONE",
+
+            _ => throw new ArgumentOutOfRangeException()
+        };
+
+        [UsedImplicitly]
+        [QueryParameter("gameMode")]
+        private string PlaylistNames => Playlist.Expand();
+
+        [UsedImplicitly]
+        [QueryParameter("startDate")]
+        protected virtual string FormattedStartDate => StartDate.UtcDateTime.ToString(DateTimeFormat);
+
+        [UsedImplicitly]
+        [QueryParameter("endDate")]
+        protected virtual string FormattedEndDate => EndDate.UtcDateTime.ToString(DateTimeFormat);
+
+        [UsedImplicitly]
+        [QueryParameter("teamRole")]
+        protected virtual string OperatorTypeNames => OperatorType.HasFlag(OperatorType.Independent)
+            // independent = all
+            ? (OperatorType.Attacker | OperatorType.Defender).Expand() + ",all"
+            // here we remove the independent flag then expand
+            : (OperatorType & ~OperatorType.Independent).Expand();
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Requests/ModernMapStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernMapStatsRequest.cs
@@ -1,0 +1,17 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using DragonFruit.Six.Api.Accounts.Entities;
+
+namespace DragonFruit.Six.Api.Modern.Requests
+{
+    public class ModernMapStatsRequest : ModernStatsRequest
+    {
+        protected override string RequestType => "maps";
+
+        public ModernMapStatsRequest(UbisoftAccount account)
+            : base(account)
+        {
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Requests/ModernOperatorStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernOperatorStatsRequest.cs
@@ -1,0 +1,17 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using DragonFruit.Six.Api.Accounts.Entities;
+
+namespace DragonFruit.Six.Api.Modern.Requests
+{
+    public class ModernOperatorStatsRequest : ModernStatsRequest
+    {
+        protected override string RequestType => "operators";
+
+        public ModernOperatorStatsRequest(UbisoftAccount account)
+            : base(account)
+        {
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Requests/ModernSeasonalStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernSeasonalStatsRequest.cs
@@ -1,0 +1,42 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System;
+using DragonFruit.Six.Api.Accounts.Entities;
+using DragonFruit.Six.Api.Enums;
+
+namespace DragonFruit.Six.Api.Modern.Requests
+{
+    public class ModernSeasonalStatsRequest : ModernStatsRequest
+    {
+        protected override string RequestCategory => "seasonal";
+        protected override string RequestType => "summary";
+
+        public ModernSeasonalStatsRequest(UbisoftAccount account)
+            : base(account)
+        {
+        }
+
+        public override DateTimeOffset StartDate
+        {
+            get => default;
+            set => throw new NotSupportedException();
+        }
+
+        public override DateTimeOffset EndDate
+        {
+            get => default;
+            set => throw new NotSupportedException();
+        }
+
+        public override OperatorType OperatorType
+        {
+            get => default;
+            set => throw new NotSupportedException();
+        }
+
+        protected override string FormattedStartDate => null;
+        protected override string FormattedEndDate => null;
+        protected override string OperatorTypeNames => null;
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Requests/ModernStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernStatsRequest.cs
@@ -4,13 +4,12 @@
 using System;
 using DragonFruit.Data.Parameters;
 using DragonFruit.Six.Api.Accounts.Entities;
-using DragonFruit.Six.Api.Accounts.Enums;
 using DragonFruit.Six.Api.Enums;
 using DragonFruit.Six.Api.Modern.Enums;
 using DragonFruit.Six.Api.Modern.Utils;
 using JetBrains.Annotations;
 
-namespace DragonFruit.Six.Api.Modern
+namespace DragonFruit.Six.Api.Modern.Requests
 {
     public abstract class ModernStatsRequest : UbiApiRequest
     {
@@ -102,14 +101,7 @@ namespace DragonFruit.Six.Api.Modern
 
         [UsedImplicitly]
         [QueryParameter("platform")]
-        private string PlatformName => Account.Platform switch
-        {
-            Platform.PC => "PC",
-            Platform.PSN => "PSN",
-            Platform.XB1 => "XONE",
-
-            _ => throw new ArgumentOutOfRangeException()
-        };
+        private string PlatformName => Account.Platform.ModernName();
 
         [UsedImplicitly]
         [QueryParameter("gameMode")]

--- a/DragonFruit.Six.Api/Modern/Requests/ModernStatsSummaryRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernStatsSummaryRequest.cs
@@ -1,0 +1,17 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using DragonFruit.Six.Api.Accounts.Entities;
+
+namespace DragonFruit.Six.Api.Modern.Requests
+{
+    public class ModernStatsSummaryRequest : ModernStatsRequest
+    {
+        protected override string RequestType => "summary";
+
+        public ModernStatsSummaryRequest(UbisoftAccount account)
+            : base(account)
+        {
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Requests/ModernStatsTrendRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernStatsTrendRequest.cs
@@ -1,0 +1,36 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System;
+using DragonFruit.Data.Parameters;
+using DragonFruit.Six.Api.Accounts.Entities;
+using DragonFruit.Six.Api.Modern.Enums;
+
+namespace DragonFruit.Six.Api.Modern.Requests
+{
+    public class ModernStatsTrendRequest : ModernStatsRequest
+    {
+        private TrendSpan? _trendSpan;
+
+        protected override string RequestType => "trend";
+
+        public ModernStatsTrendRequest(UbisoftAccount account)
+            : base(account)
+        {
+        }
+
+        public TrendSpan TrendSpan
+        {
+            get => _trendSpan ??= TrendSpan.Weekly;
+            set => _trendSpan = value;
+        }
+
+        [QueryParameter("trendType")]
+        protected string TrendType => TrendSpan switch
+        {
+            TrendSpan.Weekly => "weeks",
+
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Requests/ModernStatsTrendRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernStatsTrendRequest.cs
@@ -26,11 +26,6 @@ namespace DragonFruit.Six.Api.Modern.Requests
         }
 
         [QueryParameter("trendType")]
-        protected string TrendType => TrendSpan switch
-        {
-            TrendSpan.Weekly => "weeks",
-
-            _ => throw new ArgumentOutOfRangeException()
-        };
+        protected string TrendType => TrendSpan == TrendSpan.Weekly ? "weeks" : throw new ArgumentOutOfRangeException();
     }
 }

--- a/DragonFruit.Six.Api/Modern/Requests/ModernWeaponStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernWeaponStatsRequest.cs
@@ -1,0 +1,17 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using DragonFruit.Six.Api.Accounts.Entities;
+
+namespace DragonFruit.Six.Api.Modern.Requests
+{
+    public class ModernWeaponStatsRequest : ModernStatsRequest
+    {
+        protected override string RequestType => "weapons";
+
+        public ModernWeaponStatsRequest(UbisoftAccount account)
+            : base(account)
+        {
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Utils/EnumUtils.cs
+++ b/DragonFruit.Six.Api/Modern/Utils/EnumUtils.cs
@@ -24,6 +24,9 @@ namespace DragonFruit.Six.Api.Modern.Utils
         /// <summary>
         /// Checks whether a specific flag is present.
         /// </summary>
+        /// <remarks>
+        /// Taken from https://github.com/ppy/osu-framework/blob/be97749235c2cb2e9d876a40525a6f1d7127f611/osu.Framework/Extensions/EnumExtensions/EnumExtensions.cs#L64
+        /// </remarks>
         [Pure]
         internal static unsafe bool HasFlagFast<T>(this T enumValue, T flag) where T : unmanaged, Enum
         {

--- a/DragonFruit.Six.Api/Modern/Utils/EnumUtils.cs
+++ b/DragonFruit.Six.Api/Modern/Utils/EnumUtils.cs
@@ -1,0 +1,67 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+
+namespace DragonFruit.Six.Api.Modern.Utils
+{
+    internal static class EnumUtils
+    {
+        /// <summary>
+        /// Converts a bitwise flag into a comma-separated string
+        /// </summary>
+        public static string Expand<T>(this T enumValue) where T : unmanaged, Enum
+        {
+            return string.Join(",", Enum.GetValues(typeof(T))
+                                        .Cast<T>()
+                                        .Where(x => enumValue.HasFlagFast(x))
+                                        .Select(x => x.ToString().ToLower()));
+        }
+
+        /// <summary>
+        /// Checks whether a specific flag is present.
+        /// </summary>
+        [Pure]
+        internal static unsafe bool HasFlagFast<T>(this T enumValue, T flag) where T : unmanaged, Enum
+        {
+            switch (sizeof(T))
+            {
+                case 1:
+                {
+                    var value1 = Unsafe.As<T, byte>(ref enumValue);
+                    var value2 = Unsafe.As<T, byte>(ref flag);
+                    return (value1 & value2) == value2;
+                }
+
+                case 2:
+                {
+                    var value1 = Unsafe.As<T, short>(ref enumValue);
+                    var value2 = Unsafe.As<T, short>(ref flag);
+                    return (value1 & value2) == value2;
+                }
+
+                case 4:
+                {
+                    var value1 = Unsafe.As<T, int>(ref enumValue);
+                    var value2 = Unsafe.As<T, int>(ref flag);
+                    return (value1 & value2) == value2;
+                }
+
+                case 8:
+                {
+                    var value1 = Unsafe.As<T, long>(ref enumValue);
+                    var value2 = Unsafe.As<T, long>(ref flag);
+                    return (value1 & value2) == value2;
+                }
+
+                default:
+                {
+                    throw new ArgumentException($"Invalid enum type provided: {typeof(T)}.");
+                }
+            }
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Utils/JsonPathConverter.cs
+++ b/DragonFruit.Six.Api/Modern/Utils/JsonPathConverter.cs
@@ -70,8 +70,6 @@ namespace DragonFruit.Six.Api.Modern.Utils
 
         public override bool CanConvert(Type objectType) => true;
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-        }
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) => throw new NotSupportedException();
     }
 }

--- a/DragonFruit.Six.Api/Modern/Utils/JsonPathConverter.cs
+++ b/DragonFruit.Six.Api/Modern/Utils/JsonPathConverter.cs
@@ -1,0 +1,77 @@
+﻿// Dragon6 API Copyright 2020-2021 DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Please refer to the LICENSE file for more info
+
+using System;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+
+namespace DragonFruit.Six.Api.Modern.Utils
+{
+    /// <summary>
+    /// A <see cref="JsonConverter"/> for traversing through multiple properties separated by a full stop
+    /// </summary>
+    /// <remarks>
+    /// Taken from https://automationrhapsody.com/partial-json-deserialize-jsonpath-json-net/
+    /// </remarks>
+    internal class JsonPathConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var contract = serializer.ContractResolver.ResolveContract(objectType) as JsonObjectContract;
+            var targetObj = contract?.DefaultCreator?.Invoke() ?? Activator.CreateInstance(objectType);
+            var jObject = JObject.Load(reader);
+
+            foreach (var prop in objectType.GetProperties().Where(p => p.CanRead && p.CanWrite))
+            {
+                var jsonPropertyAttr = prop.GetCustomAttributes(true).OfType<JsonPropertyAttribute>().FirstOrDefault();
+
+                if (jsonPropertyAttr == null)
+                {
+                    continue;
+                }
+
+                var token = jObject.SelectToken(jsonPropertyAttr.PropertyName);
+
+                if (token == null || token.Type == JTokenType.Null)
+                {
+                    continue;
+                }
+
+                var jsonConverterAttr = prop.GetCustomAttributes(true).OfType<JsonConverterAttribute>().FirstOrDefault();
+                object value;
+
+                if (jsonConverterAttr == null)
+                {
+                    serializer.Converters.Clear();
+                    value = token.ToObject(prop.PropertyType, serializer);
+                }
+                else
+                {
+                    value = JsonConvert.DeserializeObject(token.ToString(), prop.PropertyType, (JsonConverter)Activator.CreateInstance(jsonConverterAttr.ConverterType));
+                }
+
+                prop.SetValue(targetObj, value, null);
+            }
+
+            if (contract?.OnDeserializedCallbacks != null)
+            {
+                foreach (var callback in contract.OnDeserializedCallbacks)
+                {
+                    callback.Invoke(targetObj, serializer.Context);
+                }
+            }
+
+            return targetObj;
+        }
+
+        public override bool CanConvert(Type objectType) => true;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Utils/ModernPlatformUtils.cs
+++ b/DragonFruit.Six.Api/Modern/Utils/ModernPlatformUtils.cs
@@ -1,0 +1,23 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using System;
+using DragonFruit.Six.Api.Accounts.Enums;
+
+namespace DragonFruit.Six.Api.Modern.Utils
+{
+    public static class ModernPlatformUtils
+    {
+        /// <summary>
+        /// Converts a <see cref="Platform"/> enum to its modern string equivalent.
+        /// </summary>
+        public static string ModernName(this Platform platform) => platform switch
+        {
+            Platform.PC => "PC",
+            Platform.PSN => "PSN",
+            Platform.XB1 => "XONE",
+
+            _ => throw new ArgumentOutOfRangeException()
+        };
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Utils/ValueUtils.cs
+++ b/DragonFruit.Six.Api/Modern/Utils/ValueUtils.cs
@@ -1,0 +1,25 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace DragonFruit.Six.Api.Modern.Utils
+{
+    public static class ValueUtils
+    {
+        /// <summary>
+        /// Attempts to apply a nullable value to a field using an <see cref="Action"/>
+        /// </summary>
+        /// <param name="value">The value to set</param>
+        /// <param name="setter">The <see cref="Action"/> to invoke to set the value</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void ApplyValue<T>(T? value, Action<T> setter) where T : struct
+        {
+            if (value.HasValue)
+            {
+                setter(value.Value);
+            }
+        }
+    }
+}

--- a/DragonFruit.Six.Api/Seasonal/Requests/SeasonalStatsRequest.cs
+++ b/DragonFruit.Six.Api/Seasonal/Requests/SeasonalStatsRequest.cs
@@ -15,7 +15,7 @@ namespace DragonFruit.Six.Api.Seasonal.Requests
 {
     public sealed class SeasonalStatsRequest : PlatformSpecificRequest
     {
-        public override string Path => Platform.SeasonalStatsEndpoint();
+        public override string Path => $"{Platform.SandboxUrl()}/r6karma/players";
 
         /// <summary>
         /// Creates a seasonal stats request for the provided <see cref="UbisoftAccount"/>s


### PR DESCRIPTION
Adds the base request, enums and internal tooling needed to produce the requests correctly.
This also makes the endpoints class internal and moves endpoint generation functions to their call-spot (as they only ever have a single usage)