### PR TITLE
add operator metadata requests and extensions

### DIFF
--- a/DragonFruit.Six.Api.Tests/Data/LegacyStatsTests.cs
+++ b/DragonFruit.Six.Api.Tests/Data/LegacyStatsTests.cs
@@ -47,11 +47,21 @@ namespace DragonFruit.Six.Api.Tests.Data
             var selectedOperator = await Client.GetLegacyOperatorStatsAsync(account).ContinueWith(t => t.Result.SingleOrDefault(y => y.OperatorId == operatorIndex));
 
             Assert.IsNotNull(selectedOperator);
+
             Assert.GreaterOrEqual(selectedOperator.Kills, kills);
             Assert.GreaterOrEqual(selectedOperator.Wins, wins);
 
             Assert.IsTrue(selectedOperator.Kd > 0);
             Assert.IsTrue(selectedOperator.Wl > 0);
+        }
+
+        [Test]
+        public async Task TestOperatorMetadata()
+        {
+            var operatorInfo = await Client.GetLegacyOperatorInfoAsync();
+
+            Assert.IsNotNull(operatorInfo);
+            Assert.GreaterOrEqual(operatorInfo.Count, 50);
         }
 
         [TestCase("603fc6ba-db16-4aba-81b2-e9f9601d7d24", Platform.PC, 300)]

--- a/DragonFruit.Six.Api/Legacy/Entities/LegacyOperatorInfo.cs
+++ b/DragonFruit.Six.Api/Legacy/Entities/LegacyOperatorInfo.cs
@@ -16,29 +16,26 @@ namespace DragonFruit.Six.Api.Legacy.Entities
     [Serializable]
     public class LegacyOperatorInfo
     {
-        [JsonProperty("profile")]
-        internal string ProfileId { get; set; }
-
         /// <summary>
-        /// Operator name (from datasheet/dictionary)
+        /// Operator name
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
 
         /// <summary>
-        /// Operator Identifier (from datasheet/dictionary)
+        /// Operator Identifier
         /// </summary>
         [JsonProperty("index")]
-        public string Index { get; set; }
+        public string OperatorId { get; set; }
 
         /// <summary>
-        /// Logical order (from datasheet/dictionary)
+        /// Logical order
         /// </summary>
         [JsonProperty("ord")]
         public ushort Order { get; set; }
 
         /// <summary>
-        /// Operator Icon (from datasheet)
+        /// Operator Icon
         /// </summary>
         [JsonProperty("img")]
         public string ImageUrl { get; set; }
@@ -50,13 +47,13 @@ namespace DragonFruit.Six.Api.Legacy.Entities
         public string Organisation { get; set; }
 
         /// <summary>
-        /// The subtitle, as seen underneath the operator's name in game (from datasheet)
+        /// The subtitle, as seen underneath the operator's name in game
         /// </summary>
         [JsonProperty("sub")]
         public string Subtitle { get; set; }
 
         /// <summary>
-        /// The operator's use, attacker/defender (from datasheet)
+        /// The operator's use, attacker/defender
         /// </summary>
         [JsonProperty("type")]
         public OperatorType Type { get; set; }

--- a/DragonFruit.Six.Api/Legacy/LegacyStatsExtensions.cs
+++ b/DragonFruit.Six.Api/Legacy/LegacyStatsExtensions.cs
@@ -67,6 +67,15 @@ namespace DragonFruit.Six.Api.Legacy
         }
 
         /// <summary>
+        /// Gets a <see cref="IReadOnlyCollection{T}"/> of legacy operator metadata entries
+        /// </summary>
+        /// <param name="client">The <see cref="ApiClient"/> to use</param>
+        public static Task<IReadOnlyCollection<LegacyOperatorInfo>> GetLegacyOperatorInfoAsync(this ApiClient client)
+        {
+            return client.PerformAsync<IReadOnlyCollection<LegacyOperatorInfo>>(new LegacyOperatorInfoRequest());
+        }
+
+        /// <summary>
         /// Gets the <see cref="LegacyWeaponStats"/> for the <see cref="UbisoftAccount"/> provided
         /// </summary>
         /// <param name="client">The <see cref="Dragon6Client"/> to use</param>

--- a/DragonFruit.Six.Api/Legacy/Requests/LegacyOperatorInfoRequest.cs
+++ b/DragonFruit.Six.Api/Legacy/Requests/LegacyOperatorInfoRequest.cs
@@ -1,0 +1,12 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using DragonFruit.Data;
+
+namespace DragonFruit.Six.Api.Legacy.Requests
+{
+    public class LegacyOperatorInfoRequest : ApiRequest
+    {
+        public override string Path => $"{Endpoints.AssetsEndpoint}/data/operators.json";
+    }
+}


### PR DESCRIPTION
Metadata for all legacy operators can be fetched by calling `client.GetLegacyOperatorInfoAsync()`