### PR TITLE
fix seasonal stats extensions throwing due to platform mismatches

### DIFF
--- a/DragonFruit.Six.Api.Tests/Data/MultiPlatformTests.cs
+++ b/DragonFruit.Six.Api.Tests/Data/MultiPlatformTests.cs
@@ -1,0 +1,34 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using System.Threading.Tasks;
+using DragonFruit.Six.Api.Accounts.Enums;
+using DragonFruit.Six.Api.Legacy;
+using DragonFruit.Six.Api.Seasonal;
+using NUnit.Framework;
+
+namespace DragonFruit.Six.Api.Tests.Data
+{
+    [TestFixture]
+    public class MultiPlatformTests : Dragon6ApiTest
+    {
+        [Test]
+        public async Task MultiPlatformStatsTests()
+        {
+            var accounts = new[]
+            {
+                await GetAccountInfoFor("603fc6ba-db16-4aba-81b2-e9f9601d7d24", Platform.PC),
+                await GetAccountInfoFor("b6c8e00a-00f9-44fb-b83e-eb9135933b91", Platform.XB1)
+            };
+
+            var stats = await Client.GetLegacyStatsAsync(accounts);
+            var seasonalStats = await Client.GetSeasonalStatsAsync(accounts);
+
+            Assert.IsNotNull(stats);
+            Assert.IsNotNull(seasonalStats);
+
+            Assert.AreEqual(stats.Count, accounts.Length);
+            Assert.AreEqual(seasonalStats.Stats.Count, accounts.Length);
+        }
+    }
+}

--- a/DragonFruit.Six.Api.Tests/DragonFruit.Six.Api.Tests.csproj
+++ b/DragonFruit.Six.Api.Tests/DragonFruit.Six.Api.Tests.csproj
@@ -6,13 +6,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NUnit" Version="3.13.2"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
+        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\DragonFruit.Six.Api\DragonFruit.Six.Api.csproj"/>
+        <ProjectReference Include="..\DragonFruit.Six.Api\DragonFruit.Six.Api.csproj" />
     </ItemGroup>
 
 </Project>

--- a/DragonFruit.Six.Api/Seasonal/Entities/SeasonalStatsResponse.cs
+++ b/DragonFruit.Six.Api/Seasonal/Entities/SeasonalStatsResponse.cs
@@ -15,6 +15,7 @@ namespace DragonFruit.Six.Api.Seasonal.Entities
         [JsonProperty("players")]
         private Dictionary<string, SeasonalStats> Data { get; set; }
 
+        public IReadOnlyDictionary<string, SeasonalStats> Stats => Data;
         public SeasonalStats For(UbisoftAccount account) => For(account.ProfileId);
         public SeasonalStats For(string profileId) => Data.TryGetValue(profileId, out var data) ? data : null;
     }


### PR DESCRIPTION
this error occurred because clients were able to load seasonal stats through the extension method which failed to split the query into platform-specific subrequests.

adds tests to ensure this doesn't fall through again