### PR TITLE
add skill records

### DIFF
--- a/DragonFruit.Six.Api.Tests/Data/SeasonalStatsTests.cs
+++ b/DragonFruit.Six.Api.Tests/Data/SeasonalStatsTests.cs
@@ -41,5 +41,15 @@ namespace DragonFruit.Six.Api.Tests.Data
             Assert.IsNotNull(whiteNoise.Name);
             Assert.AreEqual(2, whiteNoise.Year);
         }
+
+        [TestCase("14c01250-ef26-4a32-92ba-e04aa557d619", Platform.PC, 17, 17)]
+        public async Task TestSeasonalRecords(string identifier, Platform platform, int season15Rank, int season21Rank)
+        {
+            var account = await GetAccountInfoFor(identifier, platform);
+            var seasons = Enumerable.Range(15, 7);
+            var stats = (await Client.GetSeasonalStatsRecordsAsync(account, seasons, BoardType.Ranked, Region.EMEA)).ToArray();
+
+            Assert.AreEqual(season15Rank, stats.SingleOrDefault(x => x.SeasonId == 15)?.Rank);
+        }
     }
 }

--- a/DragonFruit.Six.Api.Tests/Data/SeasonalStatsTests.cs
+++ b/DragonFruit.Six.Api.Tests/Data/SeasonalStatsTests.cs
@@ -42,14 +42,15 @@ namespace DragonFruit.Six.Api.Tests.Data
             Assert.AreEqual(2, whiteNoise.Year);
         }
 
-        [TestCase("14c01250-ef26-4a32-92ba-e04aa557d619", Platform.PC, 17, 17)]
-        public async Task TestSeasonalRecords(string identifier, Platform platform, int season15Rank, int season21Rank)
+        [TestCase("14c01250-ef26-4a32-92ba-e04aa557d619", Platform.PC, 0, 16)]
+        public async Task TestSeasonalRecords(string identifier, Platform platform, int season15Rank, int season17Rank)
         {
             var account = await GetAccountInfoFor(identifier, platform);
             var seasons = Enumerable.Range(15, 7);
             var stats = (await Client.GetSeasonalStatsRecordsAsync(account, seasons, BoardType.Ranked, Region.EMEA)).ToArray();
 
             Assert.AreEqual(season15Rank, stats.SingleOrDefault(x => x.SeasonId == 15)?.Rank);
+            Assert.AreEqual(season17Rank, stats.SingleOrDefault(x => x.SeasonId == 17)?.Rank);
         }
     }
 }

--- a/DragonFruit.Six.Api.Tests/DragonFruit.Six.Api.Tests.csproj
+++ b/DragonFruit.Six.Api.Tests/DragonFruit.Six.Api.Tests.csproj
@@ -6,13 +6,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="NUnit" Version="3.13.2"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
+        <PackageReference Include="NUnit" Version="3.13.3" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\DragonFruit.Six.Api\DragonFruit.Six.Api.csproj"/>
+        <ProjectReference Include="..\DragonFruit.Six.Api\DragonFruit.Six.Api.csproj" />
     </ItemGroup>
 
 </Project>

--- a/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
+++ b/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
@@ -20,13 +20,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\res\icon.png" Pack="true" PackagePath="."/>
+        <None Include="..\res\icon.png" Pack="true" PackagePath="." />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DragonFruit.Data" Version="2021.1225.0"/>
-        <PackageReference Include="DragonFruit.Data.Serializers.Newtonsoft" Version="2021.1225.0"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2021.3.0"/>
+        <PackageReference Include="DragonFruit.Data" Version="2021.1225.0" />
+        <PackageReference Include="DragonFruit.Data.Serializers.Newtonsoft" Version="2021.1225.0" />
+        <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
     </ItemGroup>
 
 </Project>

--- a/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
+++ b/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
@@ -24,9 +24,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DragonFruit.Data" Version="2021.1225.0" />
-        <PackageReference Include="DragonFruit.Data.Serializers.Newtonsoft" Version="2021.1225.0" />
+        <PackageReference Include="DragonFruit.Data" Version="2022.324.0" />
+        <PackageReference Include="DragonFruit.Data.Serializers.Newtonsoft" Version="2022.324.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
+        <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     </ItemGroup>
 
 </Project>

--- a/DragonFruit.Six.Api/Legacy/LegacyStatsExtensions.cs
+++ b/DragonFruit.Six.Api/Legacy/LegacyStatsExtensions.cs
@@ -39,7 +39,9 @@ namespace DragonFruit.Six.Api.Legacy
         public static Task<IReadOnlyDictionary<string, LegacyStats>> GetLegacyStatsAsync(this Dragon6Client client, IEnumerable<UbisoftAccount> accounts, CancellationToken token = default)
         {
             const LegacyStatTypes generalStats = LegacyStatTypes.All & ~(LegacyStatTypes.Operators | LegacyStatTypes.Weapons);
-            return GetLegacyStatsAsync(client, accounts, a => new LegacyStatsRequest(a, generalStats), LegacyStatsDeserializer.DeserializeGeneralStats, token);
+            return GetLegacyStatsImplAsync(client, accounts,
+                a => new LegacyStatsRequest(a, generalStats),
+                LegacyStatsDeserializer.DeserializeGeneralStats, token);
         }
 
         /// <summary>
@@ -63,7 +65,9 @@ namespace DragonFruit.Six.Api.Legacy
         /// <returns><see cref="IEnumerable{T}"/> of <see cref="LegacyOperatorStats"/> for the provided <see cref="UbisoftAccount"/></returns>
         public static Task<ILookup<string, LegacyOperatorStats>> GetLegacyOperatorStatsAsync(this Dragon6Client client, IEnumerable<UbisoftAccount> accounts, CancellationToken token = default)
         {
-            return GetLegacyStatsAsync(client, accounts, a => new LegacyStatsRequest(a, LegacyStatTypes.Operators), LegacyStatsDeserializer.DeserializeOperatorStats, token);
+            return GetLegacyStatsImplAsync(client, accounts,
+                a => new LegacyStatsRequest(a, LegacyStatTypes.Operators),
+                LegacyStatsDeserializer.DeserializeOperatorStats, token);
         }
 
         /// <summary>
@@ -87,7 +91,9 @@ namespace DragonFruit.Six.Api.Legacy
         /// <returns><see cref="ILookup{TKey,TElement}"/> of <see cref="LegacyWeaponStats"/> for the provided <see cref="UbisoftAccount"/></returns>
         public static Task<ILookup<string, LegacyWeaponStats>> GetLegacyWeaponStatsAsync(this Dragon6Client client, IEnumerable<UbisoftAccount> accounts, CancellationToken token = default)
         {
-            return GetLegacyStatsAsync(client, accounts, a => new LegacyStatsRequest(a, LegacyStatTypes.Weapons), LegacyStatsDeserializer.DeserializeWeaponStats, token);
+            return GetLegacyStatsImplAsync(client, accounts,
+                a => new LegacyStatsRequest(a, LegacyStatTypes.Weapons),
+                LegacyStatsDeserializer.DeserializeWeaponStats, token);
         }
 
         /// <summary>
@@ -111,10 +117,12 @@ namespace DragonFruit.Six.Api.Legacy
         /// <returns><see cref="IReadOnlyDictionary{TKey,TValue}"/> of <see cref="LegacyWeaponStats"/> for the provided <see cref="UbisoftAccount"/></returns>
         public static Task<IReadOnlyDictionary<string, LegacyLevelStats>> GetLegacyLevelAsync(this Dragon6Client client, IEnumerable<UbisoftAccount> accounts, CancellationToken token = default)
         {
-            return GetLegacyStatsAsync(client, accounts, a => new PlayerLevelStatsRequest(a), LegacyStatsDeserializer.DeserializePlayerLevelStats, token);
+            return GetLegacyStatsImplAsync(client, accounts,
+                a => new PlayerLevelStatsRequest(a),
+                LegacyStatsDeserializer.DeserializePlayerLevelStats, token);
         }
 
-        private static Task<T> GetLegacyStatsAsync<T>(ApiClient client, IEnumerable<UbisoftAccount> accounts, Func<IEnumerable<UbisoftAccount>, PlatformSpecificRequest> requestFactory, Func<JObject, T> postProcessor, CancellationToken token)
+        internal static Task<T> GetLegacyStatsImplAsync<T>(ApiClient client, IEnumerable<UbisoftAccount> accounts, Func<IEnumerable<UbisoftAccount>, PlatformSpecificRequest> requestFactory, Func<JObject, T> postProcessor, CancellationToken token)
         {
             // LegacyStatsRequest is a PlatformSpecific request, so the accounts need to be split by platform
             var requests = accounts.GroupBy(x => x.Platform).Select(x =>

--- a/DragonFruit.Six.Api/Seasonal/Entities/SeasonalStats.cs
+++ b/DragonFruit.Six.Api/Seasonal/Entities/SeasonalStats.cs
@@ -18,7 +18,10 @@ namespace DragonFruit.Six.Api.Seasonal.Entities
         public byte SeasonId { get; set; }
 
         [JsonProperty("region")]
-        public string Region { get; set; }
+        public Region Region { get; set; }
+
+        [JsonProperty("board_id")]
+        public BoardType Board { get; set; }
 
         [JsonProperty("profile_id")]
         public string ProfileId { get; set; }

--- a/DragonFruit.Six.Api/Seasonal/Entities/SeasonalStats.cs
+++ b/DragonFruit.Six.Api/Seasonal/Entities/SeasonalStats.cs
@@ -17,6 +17,9 @@ namespace DragonFruit.Six.Api.Seasonal.Entities
         [JsonProperty("season")]
         public byte SeasonId { get; set; }
 
+        [JsonProperty("region")]
+        public string Region { get; set; }
+
         [JsonProperty("profile_id")]
         public string ProfileId { get; set; }
 

--- a/DragonFruit.Six.Api/Seasonal/Enums/BoardType.cs
+++ b/DragonFruit.Six.Api/Seasonal/Enums/BoardType.cs
@@ -1,14 +1,17 @@
 ﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
+using System;
+
 namespace DragonFruit.Six.Api.Seasonal.Enums
 {
     /// <summary>
     /// Represents the seasonal ranking boards available for querying
     /// </summary>
+    [Flags]
     public enum BoardType
     {
-        Ranked,
-        Casual
+        Ranked = 1,
+        Casual = 2
     }
 }

--- a/DragonFruit.Six.Api/Seasonal/Enums/BoardType.cs
+++ b/DragonFruit.Six.Api/Seasonal/Enums/BoardType.cs
@@ -2,6 +2,9 @@
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
 using System;
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace DragonFruit.Six.Api.Seasonal.Enums
 {
@@ -9,9 +12,13 @@ namespace DragonFruit.Six.Api.Seasonal.Enums
     /// Represents the seasonal ranking boards available for querying
     /// </summary>
     [Flags]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum BoardType
     {
+        [EnumMember(Value = "pvp_ranked")]
         Ranked = 1,
+
+        [EnumMember(Value = "pvp_casual")]
         Casual = 2
     }
 }

--- a/DragonFruit.Six.Api/Seasonal/Enums/Region.cs
+++ b/DragonFruit.Six.Api/Seasonal/Enums/Region.cs
@@ -1,6 +1,7 @@
 ﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace DragonFruit.Six.Api.Seasonal.Enums
@@ -8,11 +9,12 @@ namespace DragonFruit.Six.Api.Seasonal.Enums
     /// <summary>
     /// Represents the ranked regions used in-game
     /// </summary>
+    [Flags]
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public enum Region
     {
-        EMEA,
-        NCSA,
-        APAC
+        EMEA = 1,
+        NCSA = 2,
+        APAC = 4
     }
 }

--- a/DragonFruit.Six.Api/Seasonal/Enums/Region.cs
+++ b/DragonFruit.Six.Api/Seasonal/Enums/Region.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace DragonFruit.Six.Api.Seasonal.Enums
 {
@@ -10,6 +12,7 @@ namespace DragonFruit.Six.Api.Seasonal.Enums
     /// Represents the ranked regions used in-game
     /// </summary>
     [Flags]
+    [JsonConverter(typeof(StringEnumConverter))]
     [SuppressMessage("ReSharper", "InconsistentNaming")]
     public enum Region
     {

--- a/DragonFruit.Six.Api/Seasonal/Requests/SeasonalStatsRecordRequest.cs
+++ b/DragonFruit.Six.Api/Seasonal/Requests/SeasonalStatsRecordRequest.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
 using DragonFruit.Data;
 using DragonFruit.Data.Parameters;
 using DragonFruit.Six.Api.Accounts.Entities;
@@ -52,7 +54,10 @@ namespace DragonFruit.Six.Api.Seasonal.Requests
         public Region Regions { get; set; }
 
         [QueryParameter("board_ids", CollectionConversionMode.Concatenated)]
-        private IEnumerable<string> BoardIds => Enum.GetValues(typeof(BoardType)).Cast<BoardType>().Where(x => Boards.HasFlagFast(x)).Select(SeasonalStatsRequest.GetBoardId);
+        private IEnumerable<string> BoardIds => Enum.GetValues(typeof(BoardType))
+                                                    .Cast<BoardType>()
+                                                    .Where(x => Boards.HasFlagFast(x))
+                                                    .Select(x => typeof(BoardType).GetField(x.ToString()).GetCustomAttribute<EnumMemberAttribute>()?.Value);
 
         [QueryParameter("profile_ids", CollectionConversionMode.Concatenated)]
         protected override IEnumerable<string> AccountIds => base.AccountIds;

--- a/DragonFruit.Six.Api/Seasonal/Requests/SeasonalStatsRequest.cs
+++ b/DragonFruit.Six.Api/Seasonal/Requests/SeasonalStatsRequest.cs
@@ -1,8 +1,9 @@
 ﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
-using System;
 using System.Collections.Generic;
+using System.Reflection;
+using System.Runtime.Serialization;
 using DragonFruit.Data;
 using DragonFruit.Data.Parameters;
 using DragonFruit.Six.Api.Accounts.Entities;
@@ -49,19 +50,10 @@ namespace DragonFruit.Six.Api.Seasonal.Requests
         [QueryParameter("region_id", EnumHandlingMode.String)]
         public Region Region { get; set; }
 
-        // todo board_id should be resolved via reflection
         [QueryParameter("board_id")]
-        private string BoardId => GetBoardId(Board);
+        private string BoardId => typeof(BoardType).GetField(Board.ToString()).GetCustomAttribute<EnumMemberAttribute>().Value;
 
         [QueryParameter("profile_ids", CollectionConversionMode.Concatenated)]
         protected override IEnumerable<string> AccountIds => base.AccountIds;
-
-        internal static string GetBoardId(BoardType board) => board switch
-        {
-            BoardType.Ranked => "pvp_ranked",
-            BoardType.Casual => "pvp_casual",
-
-            _ => throw new ArgumentOutOfRangeException()
-        };
     }
 }

--- a/DragonFruit.Six.Api/Seasonal/Requests/SeasonalStatsRequest.cs
+++ b/DragonFruit.Six.Api/Seasonal/Requests/SeasonalStatsRequest.cs
@@ -49,6 +49,7 @@ namespace DragonFruit.Six.Api.Seasonal.Requests
         [QueryParameter("region_id", EnumHandlingMode.String)]
         public Region Region { get; set; }
 
+        // todo board_id should be resolved via reflection
         [QueryParameter("board_id")]
         private string BoardId => GetBoardId(Board);
 

--- a/DragonFruit.Six.Api/Seasonal/SeasonStatsExtensions.cs
+++ b/DragonFruit.Six.Api/Seasonal/SeasonStatsExtensions.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using DragonFruit.Data;
 using DragonFruit.Six.Api.Accounts.Entities;
 using DragonFruit.Six.Api.Legacy;
 using DragonFruit.Six.Api.Seasonal.Entities;
@@ -16,6 +17,18 @@ namespace DragonFruit.Six.Api.Seasonal
 {
     public static class SeasonStatsExtensions
     {
+        /// <summary>
+        /// Gets a <see cref="IReadOnlyCollection{T}"/> of metadata for all seasons with stats available
+        /// </summary>
+        /// <remarks>
+        /// The information returned by this method is maintained by the Dragon6 team
+        /// </remarks>
+        /// <param name="client">The <see cref="ApiClient"/> to use</param>
+        public static Task<IReadOnlyCollection<SeasonInfo>> GetSeasonInfoAsync(this ApiClient client)
+        {
+            return client.PerformAsync<IReadOnlyCollection<SeasonInfo>>(new SeasonInfoRequest());
+        }
+
         /// <summary>
         /// Get seasonal stats for the provided <see cref="UbisoftAccount"/>
         /// </summary>
@@ -65,6 +78,24 @@ namespace DragonFruit.Six.Api.Seasonal
             return LegacyStatsExtensions.GetLegacyStatsImplAsync(client, accounts,
                 p => new SeasonalStatsRecordRequest(p, boards, seasonIds, regions),
                 j => j.SelectTokens("$..players_skill_records[*]").Select(x => x.ToObject<SeasonalStats>()), token);
+        }
+
+        /// <summary>
+        /// Get seasonal stats "records" for the provided <see cref="UbisoftAccount"/>s
+        /// </summary>
+        /// <param name="client">The <see cref="Dragon6Client"/> to use</param>
+        /// <param name="account">The <see cref="UbisoftAccount"/> to get stats for</param>
+        /// <param name="seasonIds">The season ids. Defaults to the current season</param>
+        /// <param name="boards">The leaderboards to get rankings for</param>
+        /// <param name="regions">The regions to get stats for. Seasons after ~17 do not need to set this</param>
+        /// <param name="token">Optional cancellation token</param>
+        /// <remarks>
+        /// This call is able to return results for multiple accounts spanning large numbers of seasons, ranking boards and regions. If you need a single season, use <see cref="GetSeasonalStatsAsync(DragonFruit.Six.Api.Dragon6Client,DragonFruit.Six.Api.Accounts.Entities.UbisoftAccount,int,DragonFruit.Six.Api.Seasonal.Enums.BoardType,DragonFruit.Six.Api.Seasonal.Enums.Region,System.Threading.CancellationToken)"/> instead.
+        /// Elements are returned ungrouped and unordered due to the large ways the dataset could be sorted. It is recommended to sort then convert the returned <see cref="IEnumerable{T}"/> to an array afterwards.
+        /// </remarks>
+        public static Task<IEnumerable<SeasonalStats>> GetSeasonalStatsRecordsAsync(this Dragon6Client client, UbisoftAccount account, IEnumerable<int> seasonIds, BoardType boards, Region regions, CancellationToken token = default)
+        {
+            return GetSeasonalStatsRecordsAsync(client, account.Yield(), seasonIds, boards, regions, token);
         }
     }
 }

--- a/DragonFruit.Six.Api/Seasonal/SeasonStatsExtensions.cs
+++ b/DragonFruit.Six.Api/Seasonal/SeasonStatsExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DragonFruit.Six.Api.Accounts.Entities;
@@ -9,6 +10,7 @@ using DragonFruit.Six.Api.Seasonal.Entities;
 using DragonFruit.Six.Api.Seasonal.Enums;
 using DragonFruit.Six.Api.Seasonal.Requests;
 using DragonFruit.Six.Api.Utils;
+using Newtonsoft.Json.Linq;
 
 namespace DragonFruit.Six.Api.Seasonal
 {
@@ -41,6 +43,25 @@ namespace DragonFruit.Six.Api.Seasonal
         {
             var request = new SeasonalStatsRequest(accounts, board, seasonId, region);
             return client.PerformAsync<SeasonalStatsResponse>(request, token);
+        }
+
+        /// <summary>
+        /// Get seasonal stats "records" for the provided <see cref="UbisoftAccount"/>s
+        /// </summary>
+        /// <param name="client">The <see cref="Dragon6Client"/> to use</param>
+        /// <param name="accounts">The <see cref="UbisoftAccount"/>s to get stats for</param>
+        /// <param name="seasonIds">The season ids. Defaults to the current season</param>
+        /// <param name="boards">The leaderboards to get rankings for</param>
+        /// <param name="regions">The regions to get stats for. Seasons after ~17 do not need to set this</param>
+        /// <param name="token">Optional cancellation token</param>
+        /// <remarks>
+        /// This call is able to return results for multiple accounts spanning large numbers of seasons, ranking boards and regions. If you need a single season, use <see cref="GetSeasonalStatsAsync(DragonFruit.Six.Api.Dragon6Client,DragonFruit.Six.Api.Accounts.Entities.UbisoftAccount,int,DragonFruit.Six.Api.Seasonal.Enums.BoardType,DragonFruit.Six.Api.Seasonal.Enums.Region,System.Threading.CancellationToken)"/> instead.
+        /// Elements are returned ungrouped and unordered due to the large ways the dataset could be sorted. It is recommended to sort then convert the returned <see cref="IEnumerable{T}"/> to an array afterwards.
+        /// </remarks>
+        public static Task<IEnumerable<SeasonalStats>> GetSeasonalStatsRecordsAsync(this Dragon6Client client, IEnumerable<UbisoftAccount> accounts, IEnumerable<int> seasonIds, BoardType boards, Region regions, CancellationToken token = default)
+        {
+            var request = new SeasonalStatsRecordRequest(accounts, boards, seasonIds, regions);
+            return client.PerformAsync<JObject>(request, token).ContinueWith(r => r.Result.SelectTokens("$..players_skill_records[*]").Select(x => x.ToObject<SeasonalStats>()));
         }
     }
 }


### PR DESCRIPTION
Closes #293

Adds support for batch lookups of users on a single platform over multiple seasons, boards and regions. Extensions support any account (regardless of platform) by partitioning into platforms and making a separate request for each.

Updates dependencies (closes #294) and adds some `EnumMemberAttribute`s to `BoardType`