### PR TITLE
change modern stats JPath handling

### DIFF
--- a/DragonFruit.Six.Api.Tests/Data/ModernStatsTests.cs
+++ b/DragonFruit.Six.Api.Tests/Data/ModernStatsTests.cs
@@ -22,7 +22,7 @@ namespace DragonFruit.Six.Api.Tests.Data
             var data = await Client.GetModernStatsSummaryAsync(account);
 
             // summaries are returned in an array but there should only be one entry
-            data?.AllModes.AsAny.SingleOrDefault();
+            var stats = data?.AllModes.AsAny.SingleOrDefault();
         }
 
         [TestCase("14c01250-ef26-4a32-92ba-e04aa557d619", Platform.PC)]

--- a/DragonFruit.Six.Api/Modern/Containers/ModernModeStatsContainer.cs
+++ b/DragonFruit.Six.Api/Modern/Containers/ModernModeStatsContainer.cs
@@ -1,38 +1,29 @@
 ﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
-using System;
-using DragonFruit.Six.Api.Modern.Enums;
 using DragonFruit.Six.Api.Modern.Utils;
 using Newtonsoft.Json;
 
 namespace DragonFruit.Six.Api.Modern.Containers
 {
+    [JsonPathSerializable]
     [JsonObject(MemberSerialization.OptIn)]
-    [JsonConverter(typeof(JsonPathConverter))]
     public class ModernModeStatsContainer<T>
     {
-        [JsonIgnore]
-        public ModernRoleStatsContainer<T> this[PlaylistType type] => type switch
-        {
-            PlaylistType.Casual => Casual,
-            PlaylistType.Ranked => Ranked,
-            PlaylistType.Unranked => Unranked,
-            PlaylistType.Independent => AllModes,
-
-            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
-        };
-
-        [JsonProperty("gameModes.all")]
+        [JsonProperty("all")]
+        [JsonPath("gameModes.all")]
         public ModernRoleStatsContainer<T> AllModes { get; set; }
 
-        [JsonProperty("gameModes.casual")]
+        [JsonProperty("casual")]
+        [JsonPath("gameModes.casual")]
         public ModernRoleStatsContainer<T> Casual { get; set; }
 
-        [JsonProperty("gameModes.ranked")]
+        [JsonProperty("ranked")]
+        [JsonPath("gameModes.ranked")]
         public ModernRoleStatsContainer<T> Ranked { get; set; }
 
-        [JsonProperty("gameModes.unranked")]
+        [JsonProperty("unranked")]
+        [JsonPath("gameModes.unranked")]
         public ModernRoleStatsContainer<T> Unranked { get; set; }
     }
 }

--- a/DragonFruit.Six.Api/Modern/Containers/ModernRoleStatsContainer.cs
+++ b/DragonFruit.Six.Api/Modern/Containers/ModernRoleStatsContainer.cs
@@ -1,33 +1,25 @@
 ﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
-using System;
-using DragonFruit.Six.Api.Enums;
 using DragonFruit.Six.Api.Modern.Utils;
 using Newtonsoft.Json;
 
 namespace DragonFruit.Six.Api.Modern.Containers
 {
+    [JsonPathSerializable]
     [JsonObject(MemberSerialization.OptIn)]
-    [JsonConverter(typeof(JsonPathConverter))]
     public class ModernRoleStatsContainer<T>
     {
-        public T this[OperatorType type] => type switch
-        {
-            OperatorType.Independent => AsAny,
-            OperatorType.Attacker => AsAttacker,
-            OperatorType.Defender => AsDefender,
-
-            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
-        };
-
-        [JsonProperty("teamRoles.all")]
+        [JsonProperty("all")]
+        [JsonPath("teamRoles.all")]
         public T AsAny { get; set; }
 
-        [JsonProperty("teamRoles.attacker")]
+        [JsonProperty("attacker")]
+        [JsonPath("teamRoles.attacker")]
         public T AsAttacker { get; set; }
 
-        [JsonProperty("teamRoles.defender")]
+        [JsonProperty("defender")]
+        [JsonPath("teamRoles.defender")]
         public T AsDefender { get; set; }
     }
 }

--- a/DragonFruit.Six.Api/Modern/Containers/WeaponSlot.cs
+++ b/DragonFruit.Six.Api/Modern/Containers/WeaponSlot.cs
@@ -7,14 +7,16 @@ using Newtonsoft.Json;
 
 namespace DragonFruit.Six.Api.Modern.Containers
 {
+    [JsonPathSerializable]
     [JsonObject(MemberSerialization.OptIn)]
-    [JsonConverter(typeof(JsonPathConverter))]
     public class WeaponSlot
     {
-        [JsonProperty("weaponSlots.primaryWeapons.weaponTypes")]
+        [JsonProperty("primary")]
+        [JsonPath("weaponSlots.primaryWeapons.weaponTypes")]
         public IEnumerable<WeaponGroup> Primary { get; set; }
 
-        [JsonProperty("weaponSlots.secondaryWeapons.weaponTypes")]
+        [JsonProperty("secondary")]
+        [JsonPath("weaponSlots.secondaryWeapons.weaponTypes")]
         public IEnumerable<WeaponGroup> Secondary { get; set; }
     }
 }

--- a/DragonFruit.Six.Api/Modern/Entities/ModernStatsBase.cs
+++ b/DragonFruit.Six.Api/Modern/Entities/ModernStatsBase.cs
@@ -8,8 +8,8 @@ using Newtonsoft.Json;
 
 namespace DragonFruit.Six.Api.Modern.Entities
 {
+    [JsonPathSerializable]
     [JsonObject(MemberSerialization.OptIn)]
-    [JsonConverter(typeof(JsonPathConverter))]
     public abstract class ModernStatsBase
     {
         private float? _roundWl, _matchWl, _kd;
@@ -117,37 +117,47 @@ namespace DragonFruit.Six.Api.Modern.Entities
 
         #region Ratios
 
-        [JsonProperty("headshotAccuracy.value")]
+        [JsonProperty("headshotAccuracy")]
+        [JsonPath("headshotAccuracy.value")]
         public float HeadshotAccuracy { get; set; }
 
-        [JsonProperty("killsPerRound.value")]
+        [JsonProperty("killsPerRound")]
+        [JsonPath("killsPerRound.value")]
         public float KillsPerRound { get; set; }
 
-        [JsonProperty("roundsWithAKill.value")]
+        [JsonProperty("roundsWithAKill")]
+        [JsonPath("roundsWithAKill.value")]
         public float RoundsWithSingleKill { get; set; }
 
-        [JsonProperty("roundsWithMultiKill.value")]
+        [JsonProperty("roundsWithMultiKill")]
+        [JsonPath("roundsWithMultiKill.value")]
         public float RoundsWithMultipleKills { get; set; }
 
-        [JsonProperty("roundsWithOpeningKill.value")]
+        [JsonProperty("roundsWithOpeningKill")]
+        [JsonPath("roundsWithOpeningKill.value")]
         public float RoundsWithFirstKill { get; set; }
 
-        [JsonProperty("roundsWithOpeningDeath.value")]
+        [JsonProperty("roundsWithOpeningDeath")]
+        [JsonPath("roundsWithOpeningDeath.value")]
         public float RoundsWithFirstDeath { get; set; }
 
-        [JsonProperty("roundsSurvived.value")]
+        [JsonProperty("roundsSurvived")]
+        [JsonPath("roundsSurvived.value")]
         public float RoundsSurvived { get; set; }
 
-        [JsonProperty("roundsWithAnAce.value")]
+        [JsonProperty("roundsWithAnAce")]
+        [JsonPath("roundsWithAnAce.value")]
         public float RoundsAced { get; set; }
 
-        [JsonProperty("roundsWithClutch.value")]
+        [JsonProperty("roundsWithClutch")]
+        [JsonPath("roundsWithClutch.value")]
         public float RoundsClutched { get; set; }
 
         /// <summary>
         /// Rounds with a kill, objective completion, survive or trade kills
         /// </summary>
-        [JsonProperty("roundsWithKOST.value")]
+        [JsonProperty("roundsWithKOST")]
+        [JsonPath("roundsWithKOST.value")]
         public float RoundsWithKillObjectiveSurvivalOrTrade { get; set; }
 
         public float Kd => _kd ??= RatioUtils.RatioOf(Kills, Deaths);

--- a/DragonFruit.Six.Api/Modern/ModernStatsDeserializer.cs
+++ b/DragonFruit.Six.Api/Modern/ModernStatsDeserializer.cs
@@ -4,6 +4,7 @@
 using DragonFruit.Six.Api.Modern.Containers;
 using DragonFruit.Six.Api.Modern.Requests;
 using DragonFruit.Six.Api.Modern.Utils;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace DragonFruit.Six.Api.Modern
@@ -16,7 +17,10 @@ namespace DragonFruit.Six.Api.Modern
         public static ModernModeStatsContainer<T> ProcessData<T>(this JObject source, ModernStatsRequest request)
         {
             var data = source?["platforms"]?[request.Account.Platform.ModernName()];
-            return data?.ToObject<ModernModeStatsContainer<T>>();
+            return data?.ToObject<ModernModeStatsContainer<T>>(new JsonSerializer
+            {
+                Converters = { new JsonPathConverter() }
+            });
         }
     }
 }

--- a/DragonFruit.Six.Api/Modern/Utils/JsonPathAttribute.cs
+++ b/DragonFruit.Six.Api/Modern/Utils/JsonPathAttribute.cs
@@ -1,0 +1,17 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using System;
+
+namespace DragonFruit.Six.Api.Modern.Utils
+{
+    internal class JsonPathAttribute : Attribute
+    {
+        public JsonPathAttribute(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Utils/JsonPathSerializableAttribute.cs
+++ b/DragonFruit.Six.Api/Modern/Utils/JsonPathSerializableAttribute.cs
@@ -1,0 +1,14 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using System;
+
+namespace DragonFruit.Six.Api.Modern.Utils
+{
+    /// <summary>
+    /// Marks a class as being able to be deserialized by path reference
+    /// </summary>
+    internal class JsonPathSerializableAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
custom converters are no longer decorated, and are setup at the extension method level. This will now allow consumers to re-serialize data to client without the containers **and** without dots in property names, which will break any typescript setup.

this also removes indexers for containers, as they are completely redundant and some enum values cannot be used. unlikely to affect anyone, but is _technically_ a breaking change.

Any class decorated with `JsonPathSerializableAttribute` will use the custom serializer, which will then look for a `JsonPathAttribute` before falling back to the default `JsonPropertyAttribute`. As previously, these are explicit opt-in converters, so will skip any property that it cannot get a property name for, or is unable to read/write to.