### PR TITLE
Update data library

### DIFF
--- a/DragonFruit.Six.Api/Accounts/Requests/UbisoftGeolocationRequest.cs
+++ b/DragonFruit.Six.Api/Accounts/Requests/UbisoftGeolocationRequest.cs
@@ -3,15 +3,16 @@
 
 using DragonFruit.Data;
 using DragonFruit.Data.Extensions;
+using DragonFruit.Data.Requests;
 using DragonFruit.Six.Api.Enums;
 
 namespace DragonFruit.Six.Api.Accounts.Requests
 {
-    public class UbisoftGeolocationRequest : ApiRequest
+    public class UbisoftGeolocationRequest : ApiRequest, IRequestExecutingCallback
     {
         public override string Path => $"{Endpoints.BaseEndpoint}/v2/profiles/me/iplocation";
 
-        protected override void OnRequestExecuting(ApiClient client)
+        void IRequestExecutingCallback.OnRequestExecuting(ApiClient client)
         {
             if (client is not Dragon6Client)
             {

--- a/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
+++ b/DragonFruit.Six.Api/DragonFruit.Six.Api.csproj
@@ -24,10 +24,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DragonFruit.Data" Version="2022.324.0" />
-        <PackageReference Include="DragonFruit.Data.Serializers.Newtonsoft" Version="2022.324.0" />
+        <PackageReference Include="DragonFruit.Data" Version="2022.702.0" />
+        <PackageReference Include="DragonFruit.Data.Serializers.Newtonsoft" Version="2022.702.0" />
         <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
     </ItemGroup>
 
 </Project>

--- a/DragonFruit.Six.Api/Services/Developer/Dragon6DeveloperApiRequest.cs
+++ b/DragonFruit.Six.Api/Services/Developer/Dragon6DeveloperApiRequest.cs
@@ -1,20 +1,24 @@
 ﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
+using System.Threading.Tasks;
 using DragonFruit.Data;
 using DragonFruit.Data.Extensions;
+using DragonFruit.Data.Requests;
 
 namespace DragonFruit.Six.Api.Services.Developer
 {
-    public abstract class Dragon6DeveloperApiRequest : ApiRequest
+    public abstract class Dragon6DeveloperApiRequest : ApiRequest, IAsyncRequestExecutingCallback
     {
         protected override bool RequireAuth => true;
 
-        protected override void OnRequestExecuting(ApiClient client)
+        async ValueTask IAsyncRequestExecutingCallback.OnRequestExecutingAsync(ApiClient client)
         {
+            // get access token if using a developer client
             if (client is Dragon6DeveloperClient devClient)
             {
-                this.WithAuthHeader($"Bearer {devClient.RequestDragonFruitAccessToken().AccessToken}");
+                var token = await devClient.RequestDragonFruitAccessToken().ConfigureAwait(false);
+                this.WithAuthHeader($"Bearer {token.AccessToken}");
             }
         }
     }

--- a/DragonFruit.Six.Api/Services/Developer/Dragon6DeveloperClient.cs
+++ b/DragonFruit.Six.Api/Services/Developer/Dragon6DeveloperClient.cs
@@ -2,14 +2,17 @@
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
 using System;
+using System.Threading.Tasks;
 using DragonFruit.Six.Api.Authentication.Entities;
+using Nito.AsyncEx;
 
 namespace DragonFruit.Six.Api.Services.Developer
 {
     public class Dragon6DeveloperClient : Dragon6Client
     {
-        private readonly object _accessSync = new();
         private DragonFruitClientCredentials _access;
+
+        private readonly AsyncLock _accessSync = new();
         private readonly string _clientId, _clientSecret, _scopes;
 
         public Dragon6DeveloperClient(string clientId, string clientSecret, string scopes)
@@ -19,25 +22,30 @@ namespace DragonFruit.Six.Api.Services.Developer
             _scopes = scopes;
         }
 
-        protected override IUbisoftToken GetToken() => Perform<Dragon6Token>(new Dragon6TokenRequest());
+        protected override async ValueTask<IUbisoftToken> GetToken()
+        {
+            return await PerformAsync<Dragon6Token>(new Dragon6TokenRequest()).ConfigureAwait(false);
+        }
 
-        internal DragonFruitClientCredentials RequestDragonFruitAccessToken()
+        internal async ValueTask<DragonFruitClientCredentials> RequestDragonFruitAccessToken()
         {
             if (_access?.ExpiresUtc > DateTime.UtcNow)
             {
                 return _access;
             }
 
-            lock (_accessSync)
+            using (await _accessSync.LockAsync().ConfigureAwait(false))
             {
                 if (_access is null || _access.ExpiresUtc <= DateTime.UtcNow)
                 {
-                    _access = Perform<DragonFruitClientCredentials>(new DragonFruitClientCredentialsRequest
+                    var request = new DragonFruitClientCredentialsRequest
                     {
                         ClientId = _clientId,
                         ClientSecret = _clientSecret,
                         Scopes = _scopes
-                    });
+                    };
+
+                    _access = await PerformAsync<DragonFruitClientCredentials>(request).ConfigureAwait(false);
                 }
 
                 return _access;

--- a/DragonFruit.Six.Api/UbiApiRequest.cs
+++ b/DragonFruit.Six.Api/UbiApiRequest.cs
@@ -1,7 +1,9 @@
 ﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
+using System.Threading.Tasks;
 using DragonFruit.Data;
+using DragonFruit.Data.Requests;
 
 #nullable enable
 
@@ -11,15 +13,19 @@ namespace DragonFruit.Six.Api
     /// Represents a Ubisoft API request that requires authentication.
     /// Supports header injection via a <see cref="Dragon6Client"/>
     /// </summary>
-    public abstract class UbiApiRequest : ApiRequest
+    public abstract class UbiApiRequest : ApiRequest, IAsyncRequestExecutingCallback
     {
         protected override bool RequireAuth => true;
 
-        protected override void OnRequestExecuting(ApiClient client)
+        async ValueTask IAsyncRequestExecutingCallback.OnRequestExecutingAsync(ApiClient client)
         {
             // all ubisoft api requests need authentication
             // the Dragon6Client caches auth tokens and allows the headers to be injected
-            (client as Dragon6Client)?.RequestAccessToken().Inject(this);
+            if (client is Dragon6Client d6Client)
+            {
+                var token = await d6Client.RequestAccessToken().ConfigureAwait(false);
+                token.Inject(this);
+            }
         }
     }
 }


### PR DESCRIPTION
This _finally_ makes the entire token fetching flow asynchronous, with almost no additional pressure when pulling it from the cache, thanks to `ValueTask`s and being able to hide the `OnExecutingAsync()` methods is also a bonus.

Only breaking change is the `RequestAccessToken` now returns a `ValueTask<IUbisoftToken>`, which means the method needs to be made async, which shouldn't be an issue.

#### Extra TODOs

- [ ] update the wiki
- [ ] consider if locking should have a timeout attached