### PR TITLE
change method signature to accept a sessionid and a task over valuetask

### DIFF
--- a/DragonFruit.Six.Api/Dragon6Client.cs
+++ b/DragonFruit.Six.Api/Dragon6Client.cs
@@ -36,10 +36,11 @@ namespace DragonFruit.Six.Api
         /// <summary>
         /// Defines the procedure for retrieving a <see cref="UbisoftToken"/> for the client to use.
         /// </summary>
+        /// <param name="sessionId">The last recorded session id. This should be used to check if a new session should be created from the server</param>
         /// <remarks>
         /// It is recommended to store the token to a file and try to retrieve from there before resorting to the online systems, as accounts can be blocked due to rate-limits
         /// </remarks>
-        protected abstract ValueTask<IUbisoftToken> GetToken();
+        protected abstract Task<IUbisoftToken> GetToken(string sessionId);
 
         /// <summary>
         /// Updates the Ubi-AppId header to be supplied to each request.
@@ -77,7 +78,7 @@ namespace DragonFruit.Six.Api
                 // check again in case of a backlog
                 if (_access?.Expired is not false)
                 {
-                    var token = await GetToken().ConfigureAwait(false);
+                    var token = await GetToken(_access?.Token.SessionId).ConfigureAwait(false);
                     _access = new ClientAccessToken(token);
                 }
 

--- a/DragonFruit.Six.Api/Services/Developer/Dragon6DeveloperClient.cs
+++ b/DragonFruit.Six.Api/Services/Developer/Dragon6DeveloperClient.cs
@@ -22,7 +22,7 @@ namespace DragonFruit.Six.Api.Services.Developer
             _scopes = scopes;
         }
 
-        protected override async ValueTask<IUbisoftToken> GetToken()
+        protected override async Task<IUbisoftToken> GetToken(string sessionId)
         {
             return await PerformAsync<Dragon6Token>(new Dragon6TokenRequest()).ConfigureAwait(false);
         }


### PR DESCRIPTION
Closes #320 and adds the `sessionId` to the GetToken parameters to make it easier to determine if a session needs to be updated from ubisoft