### PR TITLE
update client token injection to be accessible outside of the library

### DIFF
--- a/DragonFruit.Six.Api/Authentication/Entities/ClientTokenInjector.cs
+++ b/DragonFruit.Six.Api/Authentication/Entities/ClientTokenInjector.cs
@@ -7,18 +7,19 @@ using DragonFruit.Data.Extensions;
 
 namespace DragonFruit.Six.Api.Authentication.Entities
 {
-    public class ClientAccessToken
+    public class ClientTokenInjector
     {
-        internal readonly IUbisoftToken Token;
         private readonly DateTime _tokenExpiryOffset;
 
-        internal ClientAccessToken(IUbisoftToken token)
+        internal ClientTokenInjector(IUbisoftToken token)
         {
             Token = token;
             _tokenExpiryOffset = new DateTime(Math.Max(Token.Expiry.Ticks - 3000000000, 0), DateTimeKind.Utc);
         }
 
         internal bool Expired => _tokenExpiryOffset < DateTime.UtcNow;
+
+        public IUbisoftToken Token { get; }
 
         /// <summary>
         /// Injects Ubisoft authentication headers into the <see cref="ApiRequest"/> provided

--- a/DragonFruit.Six.Api/Dragon6Client.cs
+++ b/DragonFruit.Six.Api/Dragon6Client.cs
@@ -18,7 +18,7 @@ namespace DragonFruit.Six.Api
 {
     public abstract class Dragon6Client : ApiClient<ApiJsonSerializer>
     {
-        private ClientAccessToken _access;
+        private ClientTokenInjector _access;
         private readonly AsyncLock _accessSync = new();
 
         protected Dragon6Client(string userAgent = null, UbisoftService app = UbisoftService.RainbowSix)
@@ -66,7 +66,7 @@ namespace DragonFruit.Six.Api
             _ => base.ValidateAndProcess<T>(response)
         };
 
-        protected internal async ValueTask<ClientAccessToken> RequestAccessToken()
+        protected internal async ValueTask<ClientTokenInjector> RequestToken()
         {
             if (_access?.Expired is false)
             {
@@ -79,7 +79,7 @@ namespace DragonFruit.Six.Api
                 if (_access?.Expired is not false)
                 {
                     var token = await GetToken(_access?.Token.SessionId).ConfigureAwait(false);
-                    _access = new ClientAccessToken(token);
+                    _access = new ClientTokenInjector(token);
                 }
 
                 return _access;

--- a/DragonFruit.Six.Api/UbiApiRequest.cs
+++ b/DragonFruit.Six.Api/UbiApiRequest.cs
@@ -23,7 +23,7 @@ namespace DragonFruit.Six.Api
             // the Dragon6Client caches auth tokens and allows the headers to be injected
             if (client is Dragon6Client d6Client)
             {
-                var token = await d6Client.RequestAccessToken().ConfigureAwait(false);
+                var token = await d6Client.RequestToken().ConfigureAwait(false);
                 token.Inject(this);
             }
         }


### PR DESCRIPTION
Renames `RequestAccessToken` to `RequestToken` and publicly exposes `Token` property of the token injector