### PR TITLE
Fix ubi urls

### DIFF
--- a/DragonFruit.Six.Api/Modern/Containers/ModernStatsTrendPointCollection.cs
+++ b/DragonFruit.Six.Api/Modern/Containers/ModernStatsTrendPointCollection.cs
@@ -1,0 +1,28 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using Newtonsoft.Json;
+
+namespace DragonFruit.Six.Api.Modern.Containers
+{
+    /// <summary>
+    /// Represents a time-series collection of values
+    /// </summary>
+    public class ModernStatsTrendPointCollection
+    {
+        [JsonProperty("actuals")]
+        public float[] Values { get; set; }
+
+        [JsonProperty("trend")]
+        public float[] Trend { get; set; }
+
+        [JsonProperty("average")]
+        public float Average { get; set; }
+
+        [JsonProperty("high")]
+        public float Max { get; set; }
+
+        [JsonProperty("low")]
+        public float Min { get; set; }
+    }
+}

--- a/DragonFruit.Six.Api/Modern/Entities/ModernStatsBase.cs
+++ b/DragonFruit.Six.Api/Modern/Entities/ModernStatsBase.cs
@@ -4,6 +4,7 @@
 using System;
 using DragonFruit.Six.Api.Modern.Utils;
 using DragonFruit.Six.Api.Utils;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 
 namespace DragonFruit.Six.Api.Modern.Entities
@@ -17,6 +18,14 @@ namespace DragonFruit.Six.Api.Modern.Entities
 
         [JsonProperty("statsDetail")]
         public string Name { get; set; }
+
+        [CanBeNull]
+        [JsonProperty("seasonNumber")]
+        public string SeasonNumber { get; set; }
+
+        [CanBeNull]
+        [JsonProperty("seasonYear")]
+        public string SeasonYear { get; set; }
 
         #region Match Stats
 

--- a/DragonFruit.Six.Api/Modern/Entities/ModernStatsTrend.cs
+++ b/DragonFruit.Six.Api/Modern/Entities/ModernStatsTrend.cs
@@ -1,8 +1,6 @@
 ﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
-using System.Collections.Generic;
-using System.Linq;
 using DragonFruit.Six.Api.Modern.Containers;
 using Newtonsoft.Json;
 
@@ -11,137 +9,40 @@ namespace DragonFruit.Six.Api.Modern.Entities
     [JsonObject(MemberSerialization.OptIn)]
     public class ModernStatsTrend
     {
-        [JsonProperty("statsPeriod")]
-        public string[] StatsPeriods { get; set; }
-
-        #region Matches/Rounds
-
-        [JsonProperty("matchesPlayed")]
-        public int[] MatchesPlayed { get; set; }
-
-        [JsonProperty("roundsPlayed")]
-        public int[] RoundsPlayed { get; set; }
-
-        [JsonProperty("minutesPlayed")]
-        public int[] MinutesPlayed { get; set; }
-
-        [JsonProperty("matchesWon")]
-        public int[] MatchesWon { get; set; }
-
-        [JsonProperty("matchesLost")]
-        public int[] MatchesLost { get; set; }
-
-        [JsonProperty("roundsWon")]
-        public int[] RoundsWon { get; set; }
-
-        [JsonProperty("roundsLost")]
-        public int[] RoundsLost { get; set; }
-
-        #endregion
-
-        #region Kills/Deaths
-
-        [JsonProperty("kills")]
-        public int[] Kills { get; set; }
-
-        [JsonProperty("assists")]
-        public int[] Assists { get; set; }
-
-        [JsonProperty("death")]
-        public int[] Deaths { get; set; }
-
-        [JsonProperty("headshots")]
-        public int[] Headshots { get; set; }
-
-        [JsonProperty("meleeKills")]
-        public int[] MeleeKills { get; set; }
-
-        [JsonProperty("teamKills")]
-        public int[] TeamKills { get; set; }
-
-        [JsonProperty("openingKills")]
-        public int[] OpeningKills { get; set; }
-
-        [JsonProperty("openingDeaths")]
-        public int[] OpeningDeaths { get; set; }
-
-        [JsonProperty("trades")]
-        public int[] Trades { get; set; }
-
-        [JsonProperty("openingKillTrades")]
-        public int[] OpeningKillTrades { get; set; }
-
-        [JsonProperty("openingDeathTrades")]
-        public int[] OpeningDeathTrades { get; set; }
-
-        [JsonProperty("revives")]
-        public int[] Revives { get; set; }
-
-        #endregion
-
-        #region Ratios
-
         [JsonProperty("winLossRatio")]
-        public float[] Wl { get; set; }
+        public ModernStatsTrendPointCollection Wl { get; set; }
 
         [JsonProperty("killDeathRatio")]
-        public float[] Kd { get; set; }
+        public ModernStatsTrendPointCollection Kd { get; set; }
 
         [JsonProperty("headshotAccuracy")]
-        public float[] HeadshotAccuracy { get; set; }
+        public ModernStatsTrendPointCollection HeadshotAccuracy { get; set; }
 
         [JsonProperty("killsPerRound")]
-        public float[] KillsPerRound { get; set; }
-
-        #endregion
-
-        #region Rounds (Extended Info)
+        public ModernStatsTrendPointCollection KillsPerRound { get; set; }
 
         [JsonProperty("roundsWithAKill")]
-        public float[] RoundsWithAKill { get; set; }
+        public ModernStatsTrendPointCollection RoundsWithAKill { get; set; }
 
         [JsonProperty("roundsWithMultiKill")]
-        public float[] RoundsWithMultiKill { get; set; }
+        public ModernStatsTrendPointCollection RoundsWithMultiKill { get; set; }
 
         [JsonProperty("roundsWithOpeningKill")]
-        public float[] RoundsWithOpeningKill { get; set; }
+        public ModernStatsTrendPointCollection RoundsWithOpeningKill { get; set; }
 
         [JsonProperty("roundsWithOpeningDeath")]
-        public float[] RoundsWithOpeningDeath { get; set; }
+        public ModernStatsTrendPointCollection RoundsWithOpeningDeath { get; set; }
 
         [JsonProperty("roundsWithKOST")]
-        public float[] RoundsWithKost { get; set; }
+        public ModernStatsTrendPointCollection RoundsWithKost { get; set; }
 
         [JsonProperty("roundsSurvived")]
-        public float[] RoundsSurvived { get; set; }
+        public ModernStatsTrendPointCollection RoundsSurvived { get; set; }
 
-        [JsonProperty("roundsWithAnAce")]
-        public float[] RoundsWithAnAce { get; set; }
-
-        [JsonProperty("roundsWithClutch")]
-        public int[] RoundsWithClutch { get; set; }
-
-        #endregion
-
-        #region Time/Distance
-
-        [JsonProperty("timeAlivePerMatch")]
-        public float[] TimeAlivePerMatch { get; set; }
-
-        [JsonProperty("timeDeadPerMatch")]
-        public float[] TimeDeadPerMatch { get; set; }
-
-        [JsonProperty("distanceTravelled")]
-        public int[] DistanceTravelled { get; set; }
+        [JsonProperty("ratioTimeAlivePerMatch")]
+        public ModernStatsTrendPointCollection TimeAlivePerMatch { get; set; }
 
         [JsonProperty("distancePerRound")]
-        public float[] DistancePerRound { get; set; }
-
-        #endregion
-
-        public IEnumerable<ModernStatsTrendPeriod<T>> Collate<T>(IEnumerable<T> data)
-        {
-            return StatsPeriods.Zip(data, (period, values) => new ModernStatsTrendPeriod<T>(period, values));
-        }
+        public ModernStatsTrendPointCollection DistancePerRound { get; set; }
     }
 }

--- a/DragonFruit.Six.Api/Modern/Enums/TrendSpan.cs
+++ b/DragonFruit.Six.Api/Modern/Enums/TrendSpan.cs
@@ -5,6 +5,7 @@ namespace DragonFruit.Six.Api.Modern.Enums
 {
     public enum TrendSpan
     {
+        Daily,
         Weekly
     }
 }

--- a/DragonFruit.Six.Api/Modern/Requests/ModernStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernStatsRequest.cs
@@ -20,7 +20,7 @@ namespace DragonFruit.Six.Api.Modern.Requests
         private OperatorType? _operatorType;
         private DateTimeOffset? _startDate, _endDate;
 
-        public override string Path => $"https://prod.datadev.ubisoft.com/v1/profiles/{Account.ProfileId}";
+        public override string Path => $"https://prod.datadev.ubisoft.com/v1/profiles/{Account.ProfileId}/playerstats";
 
         protected ModernStatsRequest(UbisoftAccount account)
         {

--- a/DragonFruit.Six.Api/Modern/Requests/ModernStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernStatsRequest.cs
@@ -20,25 +20,12 @@ namespace DragonFruit.Six.Api.Modern.Requests
         private OperatorType? _operatorType;
         private DateTimeOffset? _startDate, _endDate;
 
-        public override string Path => $"https://r6s-stats.ubisoft.com/v1/{RequestCategory}/{RequestType}/{Account.ProfileId}";
+        public override string Path => $"https://prod.datadev.ubisoft.com/v1/profiles/{Account.ProfileId}";
 
         protected ModernStatsRequest(UbisoftAccount account)
         {
             Account = account ?? throw new NullReferenceException();
         }
-
-        /// <summary>
-        /// The category the request fits in (i.e. current, seasonal, narrative, etc.)
-        /// </summary>
-        protected virtual string RequestCategory => "current";
-
-        /// <summary>
-        /// The type of request (general, operators, weapons, etc.)
-        /// </summary>
-        /// <remarks>
-        /// This is the string included in the uri
-        /// </remarks>
-        protected abstract string RequestType { get; }
 
         /// <summary>
         /// The account to get stats for
@@ -99,9 +86,30 @@ namespace DragonFruit.Six.Api.Modern.Requests
             }
         }
 
+        /// <summary>
+        /// The type of request (general, operators, weapons, etc.)
+        /// </summary>
+        /// <remarks>
+        /// This is the string included in the uri
+        /// </remarks>
+        [UsedImplicitly]
+        [QueryParameter("aggregation")]
+        protected abstract string RequestType { get; }
+
+        /// <summary>
+        /// The category the request fits in (i.e. current, seasonal, narrative, etc.)
+        /// </summary>
+        [UsedImplicitly]
+        [QueryParameter("view")]
+        protected virtual string RequestCategory => "current";
+
         [UsedImplicitly]
         [QueryParameter("platform")]
         protected string PlatformName => Account.Platform.ModernName();
+
+        [UsedImplicitly]
+        [QueryParameter("spaceId")]
+        protected string GameSpaceId => Account.Platform.GameSpaceId();
 
         [UsedImplicitly]
         [QueryParameter("gameMode")]

--- a/DragonFruit.Six.Api/Modern/Requests/ModernStatsTrendRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernStatsTrendRequest.cs
@@ -1,7 +1,6 @@
 ﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
-using System;
 using DragonFruit.Data.Parameters;
 using DragonFruit.Six.Api.Accounts.Entities;
 using DragonFruit.Six.Api.Modern.Enums;
@@ -12,7 +11,7 @@ namespace DragonFruit.Six.Api.Modern.Requests
     {
         private TrendSpan? _trendSpan;
 
-        protected override string RequestType => "trend";
+        protected override string RequestType => "movingpoint";
 
         public ModernStatsTrendRequest(UbisoftAccount account)
             : base(account)
@@ -26,6 +25,6 @@ namespace DragonFruit.Six.Api.Modern.Requests
         }
 
         [QueryParameter("trendType")]
-        protected string TrendType => TrendSpan == TrendSpan.Weekly ? "weeks" : throw new ArgumentOutOfRangeException();
+        protected string TrendType => TrendSpan.ToString().ToLowerInvariant();
     }
 }


### PR DESCRIPTION
This fixes the errors that now occur due to ubisoft shutting down the current url that was being used by the api. It's been replaced with one that is basically the same with a couple extra query params that can be derived with information already known.

### Breaking changes
- Trends have been changed to a reduced set, and have min/max/mean values as well as the original data and a trendline set.
- Trends can also be selected daily or weekly, with weekly still being the default choice

### Next steps
This is an emergency fix, but adding summaries for specific seasons will now work and getting a list of all season summaries should be supported too.