### PR TITLE
Cleanup unit tests

### DIFF
--- a/DragonFruit.Six.Api.Tests/Data/LegacyStatsTests.cs
+++ b/DragonFruit.Six.Api.Tests/Data/LegacyStatsTests.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using System.Threading.Tasks;
-using DragonFruit.Six.Api.Accounts.Enums;
 using DragonFruit.Six.Api.Legacy;
 using DragonFruit.Six.Api.Legacy.Entities;
 using NUnit.Framework;
@@ -13,12 +12,11 @@ namespace DragonFruit.Six.Api.Tests.Data
     [TestFixture]
     public class LegacyStatsTests : Dragon6ApiTest
     {
-        [TestCase("14c01250-ef26-4a32-92ba-e04aa557d619", Platform.PC, 7600, 590)]
-        [TestCase("a5e7c9c4-a225-4d8e-810f-0c529d829a34", Platform.PSN, 6000, 470)]
-        public async Task TestGeneralStats(string userId, Platform platform, int expectedOverallKills, int expectedTimePlayedHours)
+        [TestCase("14c01250-ef26-4a32-92ba-e04aa557d619", 7600, 590)]
+        [TestCase("a5e7c9c4-a225-4d8e-810f-0c529d829a34", 6000, 470)]
+        public async Task TestGeneralStats(string userId, int expectedOverallKills, int expectedTimePlayedHours)
         {
-            var account = await GetAccountInfoFor(userId, platform);
-            var stats = await Client.GetLegacyStatsAsync(account);
+            var stats = await Client.GetLegacyStatsAsync(Accounts[userId]);
 
             Assert.GreaterOrEqual(stats.Overall.Kills, expectedOverallKills);
             Assert.GreaterOrEqual(stats.Overall.TimePlayed.TotalHours, expectedTimePlayedHours);
@@ -27,24 +25,22 @@ namespace DragonFruit.Six.Api.Tests.Data
             Assert.NotZero(stats.Secure.Highscore);
         }
 
-        [TestCase("3dc3cd27-8eb7-4fe0-8774-1006a8f509a2", Platform.PC, 845, 200)]
-        [TestCase("b6c8e00a-00f9-44fb-b83e-eb9135933b91", Platform.XB1, 1570, 500)]
-        public async Task TestWeaponStats(string identifier, Platform platform, int minRifleKills, int minShotgunKills)
+        [TestCase("3dc3cd27-8eb7-4fe0-8774-1006a8f509a2", 845, 200)]
+        [TestCase("b6c8e00a-00f9-44fb-b83e-eb9135933b91", 1570, 500)]
+        public async Task TestWeaponStats(string userId, int minRifleKills, int minShotgunKills)
         {
-            var account = await GetAccountInfoFor(identifier, platform);
-            var weaponStats = (await Client.GetLegacyWeaponStatsAsync(account)).ToDictionary(x => x.Class, x => x);
+            var weaponStats = (await Client.GetLegacyWeaponStatsAsync(Accounts[userId])).ToDictionary(x => x.Class, x => x);
 
             Assert.NotZero(weaponStats.Count);
             Assert.GreaterOrEqual(weaponStats[LegacyWeaponType.Shotgun].Kills, minShotgunKills);
             Assert.GreaterOrEqual(weaponStats[LegacyWeaponType.AssaultRifle].Kills, minRifleKills);
         }
 
-        [TestCase("e76672be-1269-4afd-a1f5-d2ec6f5a2c7f", Platform.PC, "2:A", 55, 90)]
-        [TestCase("9b1918ce-a45b-4140-b1d8-7e00965fbf92", Platform.PC, "6:17", 45, 37)]
-        public async Task TestOperatorStats(string identifier, Platform platform, string operatorIndex, int kills, int wins)
+        [TestCase("e76672be-1269-4afd-a1f5-d2ec6f5a2c7f", "2:A", 55, 90)]
+        [TestCase("9b1918ce-a45b-4140-b1d8-7e00965fbf92", "6:17", 45, 37)]
+        public async Task TestOperatorStats(string userId, string operatorIndex, int kills, int wins)
         {
-            var account = await GetAccountInfoFor(identifier, platform);
-            var selectedOperator = await Client.GetLegacyOperatorStatsAsync(account).ContinueWith(t => t.Result.SingleOrDefault(y => y.OperatorId == operatorIndex));
+            var selectedOperator = await Client.GetLegacyOperatorStatsAsync(Accounts[userId]).ContinueWith(t => t.Result.SingleOrDefault(y => y.OperatorId == operatorIndex));
 
             Assert.IsNotNull(selectedOperator);
 
@@ -55,20 +51,10 @@ namespace DragonFruit.Six.Api.Tests.Data
             Assert.IsTrue(selectedOperator.Wl > 0);
         }
 
-        [Test]
-        public async Task TestOperatorMetadata()
+        [TestCase("603fc6ba-db16-4aba-81b2-e9f9601d7d24", 300)]
+        public async Task PlayerLevelStatsTest(string userId, int level)
         {
-            var operatorInfo = await Client.GetLegacyOperatorInfoAsync();
-
-            Assert.IsNotNull(operatorInfo);
-            Assert.GreaterOrEqual(operatorInfo.Count, 50);
-        }
-
-        [TestCase("603fc6ba-db16-4aba-81b2-e9f9601d7d24", Platform.PC, 300)]
-        public async Task PlayerLevelStatsTest(string identifier, Platform platform, int level)
-        {
-            var account = await GetAccountInfoFor(identifier, platform);
-            var accountLevel = await Client.GetLegacyLevelAsync(account);
+            var accountLevel = await Client.GetLegacyLevelAsync(Accounts[userId]);
 
             Assert.IsNotNull(accountLevel);
             Assert.GreaterOrEqual(accountLevel.Level, level);

--- a/DragonFruit.Six.Api.Tests/Data/ModernStatsTests.cs
+++ b/DragonFruit.Six.Api.Tests/Data/ModernStatsTests.cs
@@ -1,11 +1,14 @@
 ﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using DragonFruit.Six.Api.Accounts.Enums;
+using DragonFruit.Six.Api.Accounts.Entities;
 using DragonFruit.Six.Api.Enums;
 using DragonFruit.Six.Api.Modern;
+using DragonFruit.Six.Api.Modern.Containers;
 using DragonFruit.Six.Api.Modern.Enums;
 using NUnit.Framework;
 
@@ -14,45 +17,44 @@ namespace DragonFruit.Six.Api.Tests.Data
     [TestFixture]
     public class ModernStatsTests : Dragon6ApiTest
     {
-        [TestCase("14c01250-ef26-4a32-92ba-e04aa557d619", Platform.PC)]
-        [TestCase("d0cc86e3-f3b8-493c-bb36-c9416183477a", Platform.PC)]
-        public async Task TestModernSummary(string userId, Platform platform)
+        [TestCaseSource(nameof(Accounts))]
+        public async Task TestModernSummary(UbisoftAccount account)
         {
-            var account = await GetAccountInfoFor(userId, platform);
             var data = await Client.GetModernStatsSummaryAsync(account);
 
-            // summaries are returned in an array but there should only be one entry
-            var stats = data?.AllModes.AsAny.SingleOrDefault();
+            ValidateResponse(data, s => s.AllModes.AsAny);
+            Assert.AreEqual(1, data.AllModes.AsAny.Count());
         }
 
-        [TestCase("14c01250-ef26-4a32-92ba-e04aa557d619", Platform.PC)]
-        [TestCase("d0cc86e3-f3b8-493c-bb36-c9416183477a", Platform.PC)]
-        public async Task TestModernOperators(string userId, Platform platform)
+        [TestCaseSource(nameof(Accounts))]
+        public async Task TestModernOperators(UbisoftAccount account)
         {
-            var account = await GetAccountInfoFor(userId, platform);
             var data = await Client.GetModernOperatorStatsAsync(account, operatorType: OperatorType.Attacker);
-
-            var operators = data?.AllModes.AsAttacker;
+            ValidateResponse(data, s => s.AllModes.AsAttacker);
         }
 
-        [TestCase("14c01250-ef26-4a32-92ba-e04aa557d619", Platform.PC)]
-        [TestCase("d0cc86e3-f3b8-493c-bb36-c9416183477a", Platform.PC)]
-        public async Task TestModernWeapons(string userId, Platform platform)
+        [TestCaseSource(nameof(Accounts))]
+        public async Task TestModernWeapons(UbisoftAccount account)
         {
-            var account = await GetAccountInfoFor(userId, platform);
             var data = await Client.GetModernWeaponStatsAsync(account);
-
-            var primaryWeapons = data?.AllModes.AsDefender.Primary;
+            ValidateResponse(data, s => s.AllModes.AsDefender.Primary);
         }
 
-        [TestCase("14c01250-ef26-4a32-92ba-e04aa557d619", Platform.PC)]
-        [TestCase("d0cc86e3-f3b8-493c-bb36-c9416183477a", Platform.PC)]
-        public async Task TestModernSeasons(string userId, Platform platform)
+        [TestCaseSource(nameof(Accounts))]
+        public async Task TestModernSeasons(UbisoftAccount account)
         {
-            var account = await GetAccountInfoFor(userId, platform);
             var data = await Client.GetModernSeasonStatsAsync(account, PlaylistType.Independent);
+            ValidateResponse(data, s => s.AllModes.AsAny);
+        }
 
-            var seasons = data?.AllModes.AsAny;
+        private static void ValidateResponse<T, TTarget>(ModernModeStatsContainer<T> container, Func<ModernModeStatsContainer<T>, IEnumerable<TTarget>> selector)
+        {
+            if (container == null)
+            {
+                Assert.Inconclusive();
+            }
+
+            Assert.IsNotEmpty(selector.Invoke(container));
         }
     }
 }

--- a/DragonFruit.Six.Api.Tests/Data/SeasonalStatsTests.cs
+++ b/DragonFruit.Six.Api.Tests/Data/SeasonalStatsTests.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using System.Threading.Tasks;
-using DragonFruit.Six.Api.Accounts.Enums;
 using DragonFruit.Six.Api.Seasonal;
 using DragonFruit.Six.Api.Seasonal.Enums;
 using NUnit.Framework;
@@ -13,12 +12,14 @@ namespace DragonFruit.Six.Api.Tests.Data
     [TestFixture]
     public class SeasonalStatsTests : Dragon6ApiTest
     {
-        [TestCase("14c01250-ef26-4a32-92ba-e04aa557d619", Platform.PC, 0, 16)]
-        public async Task TestSeasonalRecords(string identifier, Platform platform, int season15Rank, int season17Rank)
+        /// <summary>
+        /// Test seasonal record deserialization is happening as expected
+        /// </summary>
+        [TestCase("14c01250-ef26-4a32-92ba-e04aa557d619", 0, 16)]
+        public async Task TestSeasonalRecords(string userId, int season15Rank, int season17Rank)
         {
-            var account = await GetAccountInfoFor(identifier, platform);
             var seasons = Enumerable.Range(15, 7);
-            var stats = (await Client.GetSeasonalStatsRecordsAsync(account, seasons, BoardType.Ranked, Region.EMEA)).ToDictionary(x => x.SeasonId);
+            var stats = (await Client.GetSeasonalStatsRecordsAsync(Accounts[userId], seasons, BoardType.Ranked, Region.EMEA)).ToDictionary(x => x.SeasonId);
 
             Assert.AreEqual(season15Rank, stats[15].Rank);
             Assert.AreEqual(season17Rank, stats[17].Rank);
@@ -30,15 +31,8 @@ namespace DragonFruit.Six.Api.Tests.Data
         [Test]
         public async Task TestMultiPlatformMultiVersionRanked()
         {
-            var accounts = new[]
-            {
-                await GetAccountInfoFor("14c01250-ef26-4a32-92ba-e04aa557d619", Platform.PC),
-                await GetAccountInfoFor("45c0cccb-a1a8-4433-b3d8-52aaa40d16d2", Platform.PC),
-                await GetAccountInfoFor("5e992dc8-7d93-4f28-9690-08b4d6788cc8", Platform.PSN)
-            };
-
-            var stats = await Client.GetSeasonalStatsRecordsAsync(accounts, new[] { 28, 27, 26, 25 });
-            Assert.AreEqual(48, stats.Count);
+            var stats = await Client.GetSeasonalStatsRecordsAsync(Accounts, new[] { 28, 27, 26, 25 });
+            Assert.Greater(stats.Count, 48);
 
             var casualMMR = stats.Single(x => x.ProfileId == "14c01250-ef26-4a32-92ba-e04aa557d619" && x.Board == BoardType.Casual && x.SeasonId == 26).MMR;
             Assert.Greater(casualMMR, 2200);

--- a/DragonFruit.Six.Api.Tests/Dragon6ApiTest.cs
+++ b/DragonFruit.Six.Api.Tests/Dragon6ApiTest.cs
@@ -1,31 +1,14 @@
 // Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using DragonFruit.Six.Api.Accounts;
-using DragonFruit.Six.Api.Accounts.Entities;
-using DragonFruit.Six.Api.Accounts.Enums;
 using DragonFruit.Six.Api.Services.Developer;
 
 namespace DragonFruit.Six.Api.Tests
 {
     public abstract class Dragon6ApiTest
     {
-        private static readonly Dictionary<string, UbisoftAccount> Accounts = new();
         protected static readonly Dragon6DeveloperClient Client = new("00000000-0000-0000-0000-000000000001.045a00e5c0", "d3574f2ae25d47f7993689f9b4ad40c2", "dragon6.token.read");
 
-        protected async Task<UbisoftAccount> GetAccountInfoFor(string identifier, Platform platform)
-        {
-            if (Accounts.TryGetValue(identifier, out var account))
-            {
-                return account;
-            }
-
-            var onlineAccount = await Client.GetAccountAsync(identifier, platform, IdentifierType.UserId).ConfigureAwait(false);
-            Accounts[onlineAccount.UbisoftId] = onlineAccount;
-
-            return onlineAccount;
-        }
+        protected static Dragon6TestAccounts Accounts = new();
     }
 }

--- a/DragonFruit.Six.Api.Tests/Dragon6TestAccounts.cs
+++ b/DragonFruit.Six.Api.Tests/Dragon6TestAccounts.cs
@@ -76,10 +76,18 @@ namespace DragonFruit.Six.Api.Tests
                 ProfileId = "603fc6ba-db16-4aba-81b2-e9f9601d7d24",
                 UbisoftId = "603fc6ba-db16-4aba-81b2-e9f9601d7d24",
                 PlatformId = "603FC6BA-DB16-4ABA-81B2-E9F9601D7D24"
+            },
+            new UbisoftAccount
+            {
+                Username = "Revilo_333",
+                Platform = Platform.PC,
+                ProfileId = "e76672be-1269-4afd-a1f5-d2ec6f5a2c7f",
+                UbisoftId = "e76672be-1269-4afd-a1f5-d2ec6f5a2c7f",
+                PlatformId = "e76672be-1269-4afd-a1f5-d2ec6f5a2c7f"
             }
         };
 
-        public UbisoftAccount this[string id] => _accounts.SingleOrDefault(x => x.UbisoftId == id);
+        public UbisoftAccount this[string id] => _accounts.FirstOrDefault(x => x.UbisoftId == id);
 
         public IEnumerator<UbisoftAccount> GetEnumerator() => _accounts.GetEnumerator();
 

--- a/DragonFruit.Six.Api.Tests/Dragon6TestAccounts.cs
+++ b/DragonFruit.Six.Api.Tests/Dragon6TestAccounts.cs
@@ -11,6 +11,11 @@ namespace DragonFruit.Six.Api.Tests
 {
     public class Dragon6TestAccounts : IEnumerable<UbisoftAccount>
     {
+        public UbisoftAccount this[string id] => _accounts.FirstOrDefault(x => x.UbisoftId == id);
+
+        public IEnumerator<UbisoftAccount> GetEnumerator() => _accounts.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
         private readonly IReadOnlyList<UbisoftAccount> _accounts = new[]
         {
             new UbisoftAccount
@@ -92,13 +97,15 @@ namespace DragonFruit.Six.Api.Tests
                 ProfileId = "9b1918ce-a45b-4140-b1d8-7e00965fbf92",
                 UbisoftId = "9b1918ce-a45b-4140-b1d8-7e00965fbf92",
                 PlatformId = "9b1918ce-a45b-4140-b1d8-7e00965fbf92"
+            },
+            new UbisoftAccount
+            {
+                Username = "Unique.Enough",
+                Platform = Platform.PC,
+                ProfileId = "3dc3cd27-8eb7-4fe0-8774-1006a8f509a2",
+                UbisoftId = "3dc3cd27-8eb7-4fe0-8774-1006a8f509a2",
+                PlatformId = "3DC3CD27-8EB7-4FE0-8774-1006A8F509A2"
             }
         };
-
-        public UbisoftAccount this[string id] => _accounts.FirstOrDefault(x => x.UbisoftId == id);
-
-        public IEnumerator<UbisoftAccount> GetEnumerator() => _accounts.GetEnumerator();
-
-        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }

--- a/DragonFruit.Six.Api.Tests/Dragon6TestAccounts.cs
+++ b/DragonFruit.Six.Api.Tests/Dragon6TestAccounts.cs
@@ -1,0 +1,88 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using DragonFruit.Six.Api.Accounts.Entities;
+using DragonFruit.Six.Api.Accounts.Enums;
+
+namespace DragonFruit.Six.Api.Tests
+{
+    public class Dragon6TestAccounts : IEnumerable<UbisoftAccount>
+    {
+        private readonly IReadOnlyList<UbisoftAccount> _accounts = new[]
+        {
+            new UbisoftAccount
+            {
+                Username = "PaPa.Curry",
+                Platform = Platform.PC,
+                ProfileId = "14c01250-ef26-4a32-92ba-e04aa557d619",
+                PlatformId = "14c01250-ef26-4a32-92ba-e04aa557d619",
+                UbisoftId = "14c01250-ef26-4a32-92ba-e04aa557d619"
+            },
+            new UbisoftAccount
+            {
+                Username = "ITFC_max",
+                Platform = Platform.PC,
+                ProfileId = "45c0cccb-a1a8-4433-b3d8-52aaa40d16d2",
+                UbisoftId = "45c0cccb-a1a8-4433-b3d8-52aaa40d16d2",
+                PlatformId = "45c0cccb-a1a8-4433-b3d8-52aaa40d16d2"
+            },
+            new UbisoftAccount
+            {
+                Username = "P9-",
+                Platform = Platform.PC,
+                ProfileId = "d0cc86e3-f3b8-493c-bb36-c9416183477a",
+                UbisoftId = "d0cc86e3-f3b8-493c-bb36-c9416183477a",
+                PlatformId = "d0cc86e3-f3b8-493c-bb36-c9416183477a"
+            },
+            new UbisoftAccount
+            {
+                Username = "TheOnePistolGuy-",
+                Platform = Platform.PSN,
+                ProfileId = "18255d23-8073-440e-9011-1b9b8faa15fe",
+                UbisoftId = "5e992dc8-7d93-4f28-9690-08b4d6788cc8",
+                PlatformId = "1678314272891637227"
+            },
+            new UbisoftAccount
+            {
+                Username = "TheKoreanKoala",
+                Platform = Platform.PSN,
+                ProfileId = "be982999-2adb-4fbe-b2a5-3cbc4b7a79bf",
+                UbisoftId = "a5e7c9c4-a225-4d8e-810f-0c529d829a34",
+                PlatformId = "7729747787525340203"
+            },
+            new UbisoftAccount
+            {
+                Username = "Charr._",
+                Platform = Platform.PC,
+                ProfileId = "a5e7c9c4-a225-4d8e-810f-0c529d829a34",
+                UbisoftId = "a5e7c9c4-a225-4d8e-810f-0c529d829a34",
+                PlatformId = "a5e7c9c4-a225-4d8e-810f-0c529d829a34"
+            },
+            new UbisoftAccount
+            {
+                Username = "Jancer",
+                Platform = Platform.XB1,
+                ProfileId = "6c5b5c77-a7db-4c5f-8802-de797ce529a8",
+                UbisoftId = "b6c8e00a-00f9-44fb-b83e-eb9135933b91",
+                PlatformId = "2535444832986122"
+            },
+            new UbisoftAccount
+            {
+                Username = "MeatyMarley",
+                Platform = Platform.PC,
+                ProfileId = "603fc6ba-db16-4aba-81b2-e9f9601d7d24",
+                UbisoftId = "603fc6ba-db16-4aba-81b2-e9f9601d7d24",
+                PlatformId = "603FC6BA-DB16-4ABA-81B2-E9F9601D7D24"
+            }
+        };
+
+        public UbisoftAccount this[string id] => _accounts.SingleOrDefault(x => x.UbisoftId == id);
+
+        public IEnumerator<UbisoftAccount> GetEnumerator() => _accounts.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+}

--- a/DragonFruit.Six.Api.Tests/Dragon6TestAccounts.cs
+++ b/DragonFruit.Six.Api.Tests/Dragon6TestAccounts.cs
@@ -84,6 +84,14 @@ namespace DragonFruit.Six.Api.Tests
                 ProfileId = "e76672be-1269-4afd-a1f5-d2ec6f5a2c7f",
                 UbisoftId = "e76672be-1269-4afd-a1f5-d2ec6f5a2c7f",
                 PlatformId = "e76672be-1269-4afd-a1f5-d2ec6f5a2c7f"
+            },
+            new UbisoftAccount
+            {
+                Username = string.Empty,
+                Platform = Platform.PC,
+                ProfileId = "9b1918ce-a45b-4140-b1d8-7e00965fbf92",
+                UbisoftId = "9b1918ce-a45b-4140-b1d8-7e00965fbf92",
+                PlatformId = "9b1918ce-a45b-4140-b1d8-7e00965fbf92"
             }
         };
 

--- a/DragonFruit.Six.Api/Modern/ModernStatsExtensions.cs
+++ b/DragonFruit.Six.Api/Modern/ModernStatsExtensions.cs
@@ -13,7 +13,6 @@ using DragonFruit.Six.Api.Modern.Entities;
 using DragonFruit.Six.Api.Modern.Enums;
 using DragonFruit.Six.Api.Modern.Requests;
 using DragonFruit.Six.Api.Modern.Utils;
-using JetBrains.Annotations;
 using Newtonsoft.Json.Linq;
 
 namespace DragonFruit.Six.Api.Modern
@@ -27,7 +26,6 @@ namespace DragonFruit.Six.Api.Modern
         /// <param name="request">The request to perform</param>
         /// <param name="token">Optional <see cref="CancellationToken"/></param>
         /// <returns>A container with the requested stats (<see cref="TResponse"/>). Will return null if no stats found</returns>
-        [CanBeNull]
         public static async Task<ModernModeStatsContainer<TResponse>> GetModernStatsAsync<TResponse>(this Dragon6Client client, ModernStatsRequest request, CancellationToken token = default)
         {
             var response = await client.PerformAsync<JObject>(request, token).ConfigureAwait(false);
@@ -45,7 +43,6 @@ namespace DragonFruit.Six.Api.Modern
         /// <param name="endDate">The last day to include stats for.</param>
         /// <param name="token">Optional <see cref="CancellationToken"/></param>
         /// <returns>A container with the requested map stats. Will return null if no stats found</returns>
-        [CanBeNull]
         public static Task<ModernModeStatsContainer<IEnumerable<ModernMapStats>>> GetModernMapStatsAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, OperatorType operatorType = OperatorType.All, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null, CancellationToken token = default)
         {
             var request = new ModernMapStatsRequest(account)
@@ -71,7 +68,6 @@ namespace DragonFruit.Six.Api.Modern
         /// <param name="endDate">The last day to include stats for.</param>
         /// <param name="token">Optional <see cref="CancellationToken"/></param>
         /// <returns>A container with the requested operator stats. Will return null if no stats found</returns>
-        [CanBeNull]
         public static Task<ModernModeStatsContainer<IEnumerable<ModernOperatorStats>>> GetModernOperatorStatsAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, OperatorType operatorType = OperatorType.All, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null, CancellationToken token = default)
         {
             var request = new ModernOperatorStatsRequest(account)
@@ -103,7 +99,6 @@ namespace DragonFruit.Six.Api.Modern
         /// <param name="playlistType">The <see cref="PlaylistType"/> to get stats for</param>
         /// <param name="token">Optional <see cref="CancellationToken"/></param>
         /// <returns>A container with all seasons tracked. Will return null if no stats found</returns>
-        [CanBeNull]
         public static Task<ModernModeStatsContainer<IEnumerable<ModernSeasonStats>>> GetModernSeasonStatsAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, CancellationToken token = default)
         {
             var request = new ModernSeasonalStatsRequest(account)
@@ -126,7 +121,6 @@ namespace DragonFruit.Six.Api.Modern
         /// <param name="token">Optional <see cref="CancellationToken"/></param>
         /// <returns>A container with the requested stats. Will return null if no stats found.</returns>
         /// <remarks>This returns a collection of <see cref="ModernStatsSummary"/> items, but is recommended to use FirstOrDefault() to get the correct stats object</remarks>
-        [CanBeNull]
         public static Task<ModernModeStatsContainer<IEnumerable<ModernStatsSummary>>> GetModernStatsSummaryAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, OperatorType operatorType = OperatorType.All, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null, CancellationToken token = default)
         {
             var request = new ModernStatsSummaryRequest(account)
@@ -152,7 +146,6 @@ namespace DragonFruit.Six.Api.Modern
         /// <param name="endDate">The last day to include stats for.</param>
         /// <param name="token">Optional <see cref="CancellationToken"/></param>
         /// <returns>A container with the data needed to plot the graphs seen on the ubisoft stats site. Will return null if no stats found</returns>
-        [CanBeNull]
         public static Task<ModernModeStatsContainer<IEnumerable<ModernStatsTrend>>> GetModernStatsTrendAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, OperatorType operatorType = OperatorType.All, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null, CancellationToken token = default)
         {
             var request = new ModernStatsTrendRequest(account)
@@ -179,7 +172,6 @@ namespace DragonFruit.Six.Api.Modern
         /// <param name="endDate">The last day to include stats for.</param>
         /// <param name="token">Optional <see cref="CancellationToken"/></param>
         /// <returns>A container with the requested weapon stats. Will return null if no stats found</returns>
-        [CanBeNull]
         public static Task<ModernModeStatsContainer<WeaponSlot>> GetModernWeaponStatsAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, OperatorType operatorType = OperatorType.All, DateTimeOffset? startDate = null, DateTimeOffset? endDate = null, CancellationToken token = default)
         {
             var request = new ModernWeaponStatsRequest(account)


### PR DESCRIPTION
This consolidates the existing unit tests to use a central account listing for evaluating stats, and forces things like seasonal lookups and modern stats to test on all platforms and test the most extreme scenarios the api will be exposed to.

Side Note: the account with the username `string.Empty` is because the account has been banned, and makes it easy to track if the api starts blocking banned user stats (unlikely)