### PR TITLE
Further Modern stats updates

### DIFF
--- a/DragonFruit.Six.Api/Modern/ModernStatsDeserializer.cs
+++ b/DragonFruit.Six.Api/Modern/ModernStatsDeserializer.cs
@@ -2,7 +2,6 @@
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
 using DragonFruit.Six.Api.Modern.Containers;
-using DragonFruit.Six.Api.Modern.Requests;
 using DragonFruit.Six.Api.Modern.Utils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -14,10 +13,12 @@ namespace DragonFruit.Six.Api.Modern
         /// <summary>
         /// Abstracts a ubisoft stats response to present the data required
         /// </summary>
-        public static ModernModeStatsContainer<T> ProcessData<T>(this JObject source, ModernStatsRequest request)
+        public static ModernModeStatsContainer<T> ProcessData<T>(this JObject source)
         {
-            var platformKey = request.PlatformGroup?.ToString().ToUpperInvariant() ?? request.Account.Platform.ModernName();
-            return source?["platforms"]?[platformKey]?.ToObject<ModernModeStatsContainer<T>>(new JsonSerializer
+            var container = (JProperty)source?["profileData"].First;
+            var platformContainer = (JProperty)container?.Value["platforms"]!.First;
+
+            return platformContainer?.Value.ToObject<ModernModeStatsContainer<T>>(new JsonSerializer
             {
                 Converters = { new JsonPathConverter() }
             });

--- a/DragonFruit.Six.Api/Modern/ModernStatsDeserializer.cs
+++ b/DragonFruit.Six.Api/Modern/ModernStatsDeserializer.cs
@@ -1,6 +1,7 @@
 ﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
+using DragonFruit.Six.Api.Accounts.Entities;
 using DragonFruit.Six.Api.Modern.Containers;
 using DragonFruit.Six.Api.Modern.Utils;
 using Newtonsoft.Json;
@@ -13,11 +14,9 @@ namespace DragonFruit.Six.Api.Modern
         /// <summary>
         /// Abstracts a ubisoft stats response to present the data required
         /// </summary>
-        public static ModernModeStatsContainer<T> ProcessData<T>(this JObject source)
+        public static ModernModeStatsContainer<T> ProcessData<T>(this JObject source, UbisoftAccount account)
         {
-            var container = (JProperty)source?["profileData"].First;
-            var platformContainer = (JProperty)container?.Value["platforms"]!.First;
-
+            var platformContainer = (JProperty)source?["profileData"]![account.ProfileId]!["platforms"]!.First;
             return platformContainer?.Value.ToObject<ModernModeStatsContainer<T>>(new JsonSerializer
             {
                 Converters = { new JsonPathConverter() }

--- a/DragonFruit.Six.Api/Modern/ModernStatsDeserializer.cs
+++ b/DragonFruit.Six.Api/Modern/ModernStatsDeserializer.cs
@@ -16,8 +16,18 @@ namespace DragonFruit.Six.Api.Modern
         /// </summary>
         public static ModernModeStatsContainer<T> ProcessData<T>(this JObject source, UbisoftAccount account)
         {
-            var platformContainer = (JProperty)source?["profileData"]![account.ProfileId]!["platforms"]!.First;
-            return platformContainer?.Value.ToObject<ModernModeStatsContainer<T>>(new JsonSerializer
+            var profileContainer = source?["profileData"].ToObject<JObject>();
+
+            if (profileContainer == null)
+            {
+                return null;
+            }
+
+            var platformContainer = profileContainer.Count == 1
+                ? profileContainer.First.Value<JProperty>().Value.ToObject<JObject>()
+                : profileContainer[account.ProfileId];
+
+            return platformContainer?["platforms"]?.First.Value<JProperty>().Value.ToObject<ModernModeStatsContainer<T>>(new JsonSerializer
             {
                 Converters = { new JsonPathConverter() }
             });

--- a/DragonFruit.Six.Api/Modern/ModernStatsExtensions.cs
+++ b/DragonFruit.Six.Api/Modern/ModernStatsExtensions.cs
@@ -29,7 +29,7 @@ namespace DragonFruit.Six.Api.Modern
         public static async Task<ModernModeStatsContainer<TResponse>> GetModernStatsAsync<TResponse>(this Dragon6Client client, ModernStatsRequest request, CancellationToken token = default)
         {
             var response = await client.PerformAsync<JObject>(request, token).ConfigureAwait(false);
-            return response.ProcessData<TResponse>();
+            return response.ProcessData<TResponse>(request.Account);
         }
 
         /// <summary>
@@ -97,13 +97,15 @@ namespace DragonFruit.Six.Api.Modern
         /// <param name="client">The <see cref="Dragon6Client"/> to use</param>
         /// <param name="account">The <see cref="UbisoftAccount"/> to get stats for</param>
         /// <param name="playlistType">The <see cref="PlaylistType"/> to get stats for</param>
+        /// <param name="crossPlatformGroup">Optional <see cref="PlatformGroup"/> to get modern cross-platform stats for.</param>
         /// <param name="token">Optional <see cref="CancellationToken"/></param>
         /// <returns>A container with all seasons tracked. Will return null if no stats found</returns>
-        public static Task<ModernModeStatsContainer<IEnumerable<ModernSeasonStats>>> GetModernSeasonStatsAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, CancellationToken token = default)
+        public static Task<ModernModeStatsContainer<IEnumerable<ModernSeasonStats>>> GetModernSeasonStatsAsync(this Dragon6Client client, UbisoftAccount account, PlaylistType playlistType = PlaylistType.All, PlatformGroup? crossPlatformGroup = null, CancellationToken token = default)
         {
             var request = new ModernSeasonalStatsRequest(account)
             {
-                Playlist = playlistType
+                Playlist = playlistType,
+                PlatformGroup = crossPlatformGroup
             };
 
             return client.GetModernStatsAsync<IEnumerable<ModernSeasonStats>>(request, token);

--- a/DragonFruit.Six.Api/Modern/ModernStatsExtensions.cs
+++ b/DragonFruit.Six.Api/Modern/ModernStatsExtensions.cs
@@ -29,7 +29,7 @@ namespace DragonFruit.Six.Api.Modern
         public static async Task<ModernModeStatsContainer<TResponse>> GetModernStatsAsync<TResponse>(this Dragon6Client client, ModernStatsRequest request, CancellationToken token = default)
         {
             var response = await client.PerformAsync<JObject>(request, token).ConfigureAwait(false);
-            return response.ProcessData<TResponse>(request);
+            return response.ProcessData<TResponse>();
         }
 
         /// <summary>

--- a/DragonFruit.Six.Api/Modern/Requests/ModernSeasonalStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernSeasonalStatsRequest.cs
@@ -2,12 +2,16 @@
 // Licensed under Apache-2. Refer to the LICENSE file for more info
 
 using System;
+using System.Collections.Generic;
+using DragonFruit.Data;
+using DragonFruit.Data.Requests;
 using DragonFruit.Six.Api.Accounts.Entities;
 using DragonFruit.Six.Api.Enums;
+using DragonFruit.Six.Api.Modern.Utils;
 
 namespace DragonFruit.Six.Api.Modern.Requests
 {
-    public class ModernSeasonalStatsRequest : ModernStatsRequest
+    public class ModernSeasonalStatsRequest : ModernStatsRequest, IRequestExecutingCallback
     {
         protected override string RequestCategory => "seasonal";
         protected override string RequestType => "summary";
@@ -38,5 +42,15 @@ namespace DragonFruit.Six.Api.Modern.Requests
         protected override string FormattedStartDate => null;
         protected override string FormattedEndDate => null;
         protected override string OperatorTypeNames => null;
+
+        void IRequestExecutingCallback.OnRequestExecuting(ApiClient client)
+        {
+            var platformQuery = !PlatformGroup.HasValue
+                ? new KeyValuePair<string, string>("platform", Account.Platform.ModernName())
+                : new KeyValuePair<string, string>("platformGroup", PlatformGroup.ToString());
+
+            Queries.Clear();
+            Queries.Add(platformQuery);
+        }
     }
 }

--- a/DragonFruit.Six.Api/Modern/Requests/ModernStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernStatsRequest.cs
@@ -156,7 +156,7 @@ namespace DragonFruit.Six.Api.Modern.Requests
 
             if (Seasons?.Any() != true)
             {
-                useCrossPlayQueries = EndDate < CrossPlatformStartDate;
+                useCrossPlayQueries = EndDate > CrossPlatformStartDate;
             }
             else
             {

--- a/DragonFruit.Six.Api/Modern/Requests/ModernStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernStatsRequest.cs
@@ -24,22 +24,21 @@ namespace DragonFruit.Six.Api.Modern.Requests
 
         private PlaylistType? _playlist;
         private OperatorType? _operatorType;
-        private PlatformGroup? _platformGroup;
         private DateTimeOffset? _startDate, _endDate;
 
-        private readonly IList<KeyValuePair<string, string>> _queries;
+        protected readonly IList<KeyValuePair<string, string>> Queries;
 
         private static readonly DateTimeOffset CrossPlatformStartDate = new(2022, 12, 6, 0, 0, 0, TimeSpan.Zero);
 
         public override string Path => $"https://prod.datadev.ubisoft.com/v1/users/{Account.UbisoftId}/playerstats";
 
-        protected override IEnumerable<KeyValuePair<string, string>> AdditionalQueries => _queries;
+        protected override IEnumerable<KeyValuePair<string, string>> AdditionalQueries => Queries;
 
         protected ModernStatsRequest(UbisoftAccount account)
         {
             Account = account ?? throw new NullReferenceException();
 
-            _queries = new List<KeyValuePair<string, string>>(1);
+            Queries = new List<KeyValuePair<string, string>>(1);
         }
 
         /// <summary>
@@ -110,11 +109,7 @@ namespace DragonFruit.Six.Api.Modern.Requests
         /// <summary>
         /// Optional <see cref="PlatformGroup"/> to override when getting cross-progression metrics
         /// </summary>
-        public PlatformGroup PlatformGroup
-        {
-            get => _platformGroup ??= Account.Platform == Platform.PC ? PlatformGroup.PC : PlatformGroup.Console;
-            set => _platformGroup = value;
-        }
+        public PlatformGroup? PlatformGroup { get; set; }
 
         /// <summary>
         /// The type of request (general, operators, weapons, etc.)
@@ -182,10 +177,10 @@ namespace DragonFruit.Six.Api.Modern.Requests
 
             var platformQuery = useCrossPlayQueries
                 ? new KeyValuePair<string, string>("platform", Account.Platform.ModernName())
-                : new KeyValuePair<string, string>("platformGroup", PlatformGroup.ToString());
+                : new KeyValuePair<string, string>("platformGroup", (PlatformGroup ?? (Account.Platform == Platform.PC ? Api.Enums.PlatformGroup.PC : Api.Enums.PlatformGroup.Console)).ToString());
 
-            _queries.Clear();
-            _queries.Add(platformQuery);
+            Queries.Clear();
+            Queries.Add(platformQuery);
         }
     }
 }

--- a/DragonFruit.Six.Api/Modern/Requests/ModernStatsRequest.cs
+++ b/DragonFruit.Six.Api/Modern/Requests/ModernStatsRequest.cs
@@ -3,30 +3,43 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DragonFruit.Data;
 using DragonFruit.Data.Parameters;
+using DragonFruit.Data.Requests;
 using DragonFruit.Six.Api.Accounts.Entities;
+using DragonFruit.Six.Api.Accounts.Enums;
 using DragonFruit.Six.Api.Enums;
 using DragonFruit.Six.Api.Modern.Enums;
 using DragonFruit.Six.Api.Modern.Utils;
+using DragonFruit.Six.Api.Seasonal.Requests;
 using JetBrains.Annotations;
 
 namespace DragonFruit.Six.Api.Modern.Requests
 {
-    public abstract class ModernStatsRequest : UbiApiRequest
+    public abstract class ModernStatsRequest : UbiApiRequest, IRequestExecutingCallback
     {
         private const string DateTimeFormat = "yyyyMMdd";
         private const int DefaultStartWindow = 14;
 
         private PlaylistType? _playlist;
         private OperatorType? _operatorType;
+        private PlatformGroup? _platformGroup;
         private DateTimeOffset? _startDate, _endDate;
 
+        private readonly IList<KeyValuePair<string, string>> _queries;
+
+        private static readonly DateTimeOffset CrossPlatformStartDate = new(2022, 12, 6, 0, 0, 0, TimeSpan.Zero);
+
         public override string Path => $"https://prod.datadev.ubisoft.com/v1/users/{Account.UbisoftId}/playerstats";
+
+        protected override IEnumerable<KeyValuePair<string, string>> AdditionalQueries => _queries;
 
         protected ModernStatsRequest(UbisoftAccount account)
         {
             Account = account ?? throw new NullReferenceException();
+
+            _queries = new List<KeyValuePair<string, string>>(1);
         }
 
         /// <summary>
@@ -92,13 +105,16 @@ namespace DragonFruit.Six.Api.Modern.Requests
         /// List of seasons to return stats for. Provides an alternative timespan compared to start-end dates.
         /// </summary>
         [QueryParameter("seasons", CollectionConversionMode.Concatenated)]
-        public virtual IEnumerable<string> Seasons { get; set; }
+        public virtual IEnumerable<ModernSeason> Seasons { get; set; }
 
         /// <summary>
         /// Optional <see cref="PlatformGroup"/> to override when getting cross-progression metrics
         /// </summary>
-        [QueryParameter("platformGroup", EnumHandlingMode.StringUpper)]
-        public PlatformGroup? PlatformGroup { get; set; }
+        public PlatformGroup PlatformGroup
+        {
+            get => _platformGroup ??= Account.Platform == Platform.PC ? PlatformGroup.PC : PlatformGroup.Console;
+            set => _platformGroup = value;
+        }
 
         /// <summary>
         /// The type of request (general, operators, weapons, etc.)
@@ -116,11 +132,6 @@ namespace DragonFruit.Six.Api.Modern.Requests
         [UsedImplicitly]
         [QueryParameter("view")]
         protected virtual string RequestCategory => "current";
-
-        [CanBeNull]
-        [UsedImplicitly]
-        [QueryParameter("platform")]
-        protected string PlatformName => PlatformGroup.HasValue ? null : Account.Platform.ModernName();
 
         [UsedImplicitly]
         [QueryParameter("spaceId")]
@@ -143,5 +154,38 @@ namespace DragonFruit.Six.Api.Modern.Requests
         [UsedImplicitly]
         [QueryParameter("teamRole")]
         protected virtual string OperatorTypeNames => OperatorType.Expand();
+
+        void IRequestExecutingCallback.OnRequestExecuting(ApiClient client)
+        {
+            bool useCrossPlayQueries;
+
+            if (Seasons?.Any() != true)
+            {
+                useCrossPlayQueries = EndDate < CrossPlatformStartDate;
+            }
+            else
+            {
+                // check seasons to make sure old and new seasons aren't mixed in
+                if (Seasons.All(x => x.SeasonNumber < SeasonalStatsRecordRequest.CrossPlatformProgressionId))
+                {
+                    useCrossPlayQueries = false;
+                }
+                else if (Seasons.All(x => x.SeasonNumber >= SeasonalStatsRecordRequest.CrossPlatformProgressionId))
+                {
+                    useCrossPlayQueries = true;
+                }
+                else
+                {
+                    throw new ArgumentException($"{nameof(Seasons)} combines both cross-platform and individual platform seasons.", nameof(Seasons));
+                }
+            }
+
+            var platformQuery = useCrossPlayQueries
+                ? new KeyValuePair<string, string>("platform", Account.Platform.ModernName())
+                : new KeyValuePair<string, string>("platformGroup", PlatformGroup.ToString());
+
+            _queries.Clear();
+            _queries.Add(platformQuery);
+        }
     }
 }

--- a/DragonFruit.Six.Api/Modern/Utils/ModernPlatformUtils.cs
+++ b/DragonFruit.Six.Api/Modern/Utils/ModernPlatformUtils.cs
@@ -14,8 +14,8 @@ namespace DragonFruit.Six.Api.Modern.Utils
         public static string ModernName(this Platform platform) => platform switch
         {
             Platform.PC => "PC",
-            Platform.PSN => "PSN",
-            Platform.XB1 => "XONE",
+            Platform.PSN => "PLAYSTATION",
+            Platform.XB1 => "XBOX",
 
             _ => throw new ArgumentOutOfRangeException()
         };

--- a/DragonFruit.Six.Api/Modern/Utils/ModernSeason.cs
+++ b/DragonFruit.Six.Api/Modern/Utils/ModernSeason.cs
@@ -1,0 +1,23 @@
+﻿// Dragon6 API Copyright DragonFruit Network <inbox@dragonfruit.network>
+// Licensed under Apache-2. Refer to the LICENSE file for more info
+
+using System;
+
+namespace DragonFruit.Six.Api.Modern.Utils
+{
+    public readonly struct ModernSeason
+    {
+        public ModernSeason(int year, int season)
+        {
+            Year = year;
+            Season = Math.Max(season, 4);
+        }
+
+        public int Year { get; }
+        public int Season { get; }
+
+        public int SeasonNumber => (Year - 1) * 4 + Season;
+
+        public override string ToString() => $"Y{Year}S{Season}";
+    }
+}


### PR DESCRIPTION
- Changes the season property in `ModernStatsRequest` to accept a struct that represents a season, `ModernSeason` (breaking)
- Adds additional checking when deciding what platform query to use
- Updates to container formats
- Removes the need to pass the initial request to the deserializer