### PR TITLE
add matches played to include()

### DIFF
--- a/DragonFruit.Six.Api/Legacy/Entities/LegacyPlaylistStats.cs
+++ b/DragonFruit.Six.Api/Legacy/Entities/LegacyPlaylistStats.cs
@@ -30,6 +30,8 @@ namespace DragonFruit.Six.Api.Legacy.Entities
             Wins += stats.Wins;
             Losses += stats.Losses;
 
+            MatchesPlayed += stats.Wins + stats.Losses + stats.Abandons;
+
             if (includeAbandonsAsLosses)
             {
                 Losses += stats.Abandons;


### PR DESCRIPTION
When running `playlist.Include(ranked)` it'll now update the `MatchesPlayed` property too